### PR TITLE
fix(#0002): update cht-datasource and auth service spec to use SettingsService

### DIFF
--- a/admin-tool/src/ts/services/cht-datasource.service.ts
+++ b/admin-tool/src/ts/services/cht-datasource.service.ts
@@ -1,16 +1,11 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import {
-  DataContext,
-  getDatasource,
-  getRemoteDataContext,
-} from '@medic/cht-datasource';
-import { firstValueFrom } from 'rxjs';
+import { DataContext, getDatasource, getRemoteDataContext } from '@medic/cht-datasource';
 
 import { SessionService } from '@admin-tool-services/session.service';
+import { SettingsService } from '@admin-tool-services/settings.service';
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class CHTDatasourceService {
   private initialized: Promise<void> | null = null;
@@ -18,15 +13,11 @@ export class CHTDatasourceService {
   private userCtx: any = null;
   private dataContext!: DataContext;
 
-  constructor(
-    private http: HttpClient,
-    private sessionService: SessionService,
-  ) {}
+  constructor(private sessionService: SessionService, private settingsService: SettingsService) {}
 
   private async init() {
     this.userCtx = this.sessionService.userCtx();
-    const settings = await firstValueFrom(this.http.get('/api/v1/settings'));
-    this.settings = settings;
+    this.settings = await this.settingsService.get();
     this.dataContext = getRemoteDataContext();
   }
 
@@ -46,23 +37,13 @@ export class CHTDatasourceService {
         ...dataSource.v1,
         hasPermissions: (permissions, user?, chtSettings?) => {
           const userRoles = user?.roles ?? this.userCtx?.roles;
-          const permsSettings =
-            chtSettings?.permissions ?? this.settings?.permissions;
-          return dataSource.v1.hasPermissions(
-            permissions,
-            userRoles,
-            permsSettings,
-          );
+          const permsSettings = chtSettings?.permissions ?? this.settings?.permissions;
+          return dataSource.v1.hasPermissions(permissions, userRoles, permsSettings);
         },
         hasAnyPermission: (permissionsGroupList, user?, chtSettings?) => {
           const userRoles = user?.roles ?? this.userCtx?.roles;
-          const permsSettings =
-            chtSettings?.permissions ?? this.settings?.permissions;
-          return dataSource.v1.hasAnyPermission(
-            permissionsGroupList,
-            userRoles,
-            permsSettings,
-          );
+          const permsSettings = chtSettings?.permissions ?? this.settings?.permissions;
+          return dataSource.v1.hasAnyPermission(permissionsGroupList, userRoles, permsSettings);
         },
       },
     };

--- a/admin-tool/tests/karma/ts/services/auth.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/auth.service.spec.ts
@@ -1,28 +1,27 @@
 import { TestBed } from '@angular/core/testing';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { of } from 'rxjs';
 
-import { HttpClient } from '@angular/common/http';
 import { SessionService } from '@admin-tool-services/session.service';
 import { AuthService } from '@admin-tool-services/auth.service';
 import { CHTDatasourceService } from '@admin-tool-services/cht-datasource.service';
+import { SettingsService } from '@admin-tool-services/settings.service';
 
 describe('AuthService', () => {
   let service: AuthService;
   let sessionService;
   let chtDatasourceService: CHTDatasourceService;
-  let http;
+  let settingsService;
 
   beforeEach(() => {
     sessionService = { userCtx: sinon.stub(), isOnlineOnly: sinon.stub() };
-    http = { get: sinon.stub().returns(of({})) };
+    settingsService = { get: sinon.stub() };
 
     TestBed.configureTestingModule({
       providers: [
         { provide: SessionService, useValue: sessionService },
-        { provide: HttpClient, useValue: http },
-      ],
+        { provide: SettingsService, useValue: settingsService },
+      ]
     });
 
     service = TestBed.inject(AuthService);
@@ -36,7 +35,7 @@ describe('AuthService', () => {
   describe('has', () => {
     it('should return false when no session', async () => {
       sessionService.userCtx.returns(null);
-      http.get.returns(of({ permissions: {} }));
+      settingsService.get.resolves({ permissions: {} });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.has('can_configure');
@@ -46,9 +45,7 @@ describe('AuthService', () => {
 
     it('should return true when user is db admin', async () => {
       sessionService.userCtx.returns({ roles: ['_admin'] });
-      http.get.returns(
-        of({ permissions: { can_backup_facilities: ['national_admin'] } }),
-      );
+      settingsService.get.resolves({ permissions: { can_backup_facilities: ['national_admin'] } });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.has(['can_backup_facilities']);
@@ -58,9 +55,7 @@ describe('AuthService', () => {
 
     it('should return false when user does not have permission', async () => {
       sessionService.userCtx.returns({ roles: ['district_admin'] });
-      http.get.returns(
-        of({ permissions: { can_backup_facilities: ['national_admin'] } }),
-      );
+      settingsService.get.resolves({ permissions: { can_backup_facilities: ['national_admin'] } });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.has('can_backup_facilities');
@@ -70,27 +65,22 @@ describe('AuthService', () => {
 
     it('should return true when user has all permissions', async () => {
       sessionService.userCtx.returns({ roles: ['national_admin'] });
-      http.get.returns(
-        of({
-          permissions: {
-            can_backup_facilities: ['national_admin'],
-            can_export_messages: ['national_admin', 'district_admin'],
-          },
-        }),
-      );
+      settingsService.get.resolves({
+        permissions: {
+          can_backup_facilities: ['national_admin'],
+          can_export_messages: ['national_admin', 'district_admin'],
+        }
+      });
       chtDatasourceService['initialized'] = null;
 
-      const result = await service.has([
-        'can_backup_facilities',
-        'can_export_messages',
-      ]);
+      const result = await service.has(['can_backup_facilities', 'can_export_messages']);
 
       expect(result).to.be.true;
     });
 
     it('should return false when admin and !permission', async () => {
       sessionService.userCtx.returns({ roles: ['_admin'] });
-      http.get.returns(of({ permissions: {} }));
+      settingsService.get.resolves({ permissions: {} });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.has(['!can_backup_facilities']);
@@ -100,11 +90,7 @@ describe('AuthService', () => {
 
     it('should return true when user has !permission they lack', async () => {
       sessionService.userCtx.returns({ roles: ['analytics'] });
-      http.get.returns(
-        of({
-          permissions: { can_backup_facilities: ['national_admin'] },
-        }),
-      );
+      settingsService.get.resolves({ permissions: { can_backup_facilities: ['national_admin'] } });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.has(['!can_backup_facilities']);
@@ -114,7 +100,7 @@ describe('AuthService', () => {
 
     it('should throw error when server is offline (503)', async () => {
       sessionService.userCtx.returns({ roles: ['district_admin'] });
-      http.get.returns(of({ permissions: {} }));
+      settingsService.get.resolves({ permissions: {} });
       chtDatasourceService['initialized'] = null;
       // Stub get() to reject with 503
       sinon.stub(chtDatasourceService, 'get').rejects({ status: 503 });
@@ -141,9 +127,7 @@ describe('AuthService', () => {
   describe('any', () => {
     it('should delegate to has() when not an array', async () => {
       sessionService.userCtx.returns({ roles: ['national_admin'] });
-      http.get.returns(
-        of({ permissions: { can_configure: ['national_admin'] } }),
-      );
+      settingsService.get.resolves({ permissions: { can_configure: ['national_admin'] } });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.any('can_configure');
@@ -153,7 +137,7 @@ describe('AuthService', () => {
 
     it('should return false when no session', async () => {
       sessionService.userCtx.returns(null);
-      http.get.returns(of({ permissions: {} }));
+      settingsService.get.resolves({ permissions: {} });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.any([['can_edit'], ['can_configure']]);
@@ -163,27 +147,22 @@ describe('AuthService', () => {
 
     it('should return true when admin and no disallowed permissions', async () => {
       sessionService.userCtx.returns({ roles: ['_admin'] });
-      http.get.returns(of({ permissions: { can_edit: ['chw'] } }));
+      settingsService.get.resolves({ permissions: { can_edit: ['chw'] } });
       chtDatasourceService['initialized'] = null;
 
-      const result = await service.any([
-        ['can_backup_facilities'],
-        ['can_export_messages'],
-      ]);
+      const result = await service.any([['can_backup_facilities'], ['can_export_messages']]);
 
       expect(result).to.be.true;
     });
 
     it('should return true when user has all permissions in one group', async () => {
       sessionService.userCtx.returns({ roles: ['district_admin'] });
-      http.get.returns(
-        of({
-          permissions: {
-            can_backup_facilities: ['national_admin', 'district_admin'],
-            can_export_messages: ['national_admin', 'district_admin'],
-          },
-        }),
-      );
+      settingsService.get.resolves({
+        permissions: {
+          can_backup_facilities: ['national_admin', 'district_admin'],
+          can_export_messages: ['national_admin', 'district_admin'],
+        }
+      });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.any([
@@ -197,9 +176,7 @@ describe('AuthService', () => {
     it('should return false when get() throws in any() path', async () => {
       sessionService.userCtx.returns({ roles: ['district_admin'] });
       chtDatasourceService['initialized'] = null;
-      sinon
-        .stub(chtDatasourceService, 'get')
-        .rejects(new Error('network error'));
+      sinon.stub(chtDatasourceService, 'get').rejects(new Error('network error'));
 
       const result = await service.any([['can_configure'], ['can_upgrade']]);
 
@@ -208,14 +185,12 @@ describe('AuthService', () => {
 
     it('should return false when user has none of the permissions in any group', async () => {
       sessionService.userCtx.returns({ roles: ['district_admin'] });
-      http.get.returns(
-        of({
-          permissions: {
-            can_backup_facilities: ['national_admin'],
-            can_backup_people: ['national_admin'],
-          },
-        }),
-      );
+      settingsService.get.resolves({
+        permissions: {
+          can_backup_facilities: ['national_admin'],
+          can_backup_people: ['national_admin'],
+        }
+      });
       chtDatasourceService['initialized'] = null;
 
       const result = await service.any([

--- a/admin-tool/tsconfig.spec.json
+++ b/admin-tool/tsconfig.spec.json
@@ -15,6 +15,5 @@
   "include": [
     "tests/karma/**/*.spec.ts",
     "tests/karma/**/*.d.ts",
-    "src/ts/**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
fix(#0002): restore auth.service.spec.ts and cht-datasource.service.ts after rebase conflict

During the rebase onto 7369-admin-angular-upgrade, two files were incorrectly resolved, 
leaving older versions in place:

- admin-tool/tests/karma/ts/services/auth.service.spec.ts
- admin-tool/src/ts/services/cht-datasource.service.ts

This patch restores the correct versions of both files.