### PR TITLE
feat(#021): implement edit and delete user

### DIFF
--- a/admin-tool/src/ts/modules/users/ts/components/create-user/create-user.component.less
+++ b/admin-tool/src/ts/modules/users/ts/components/create-user/create-user.component.less
@@ -1,8 +1,17 @@
 @import 'variables';
 
 .modal {
+  display: block;
+
   &.in {
     opacity: 1;
+  }
+
+  .modal-dialog {
+    width: 50%;
+    min-width: 30rem;
+    max-width: 50rem;
+    margin: 5% auto;
   }
 
   .modal-header {

--- a/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.html
@@ -16,7 +16,7 @@
           >
             <span aria-hidden="true">&times;</span>
           </button>
-          <h4 class="modal-title">{{ 'Delete User' | translate }}</h4>
+          <h4 class="modal-title">{{ 'Confirm' | translate }}</h4>
         </div>
 
         <div class="modal-body">
@@ -43,7 +43,7 @@
           <button
             type="button"
             class="btn btn-danger"
-            (click)="submit()"
+            (click)="confirm()"
             [disabled]="loading"
           >
             @if (loading) {

--- a/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.html
@@ -1,0 +1,64 @@
+<div>
+  <div
+    class="modal fade"
+    [class.in]="visible"
+    [style.display]="visible ? 'block' : 'none'"
+    role="dialog"
+  >
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button
+            type="button"
+            class="close"
+            (click)="cancel()"
+            aria-label="Close"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title">{{ 'Delete User' | translate }}</h4>
+        </div>
+
+        <div class="modal-body">
+          @if (error) {
+            <p class="alert alert-danger" role="alert">
+              {{ error | translate }}
+            </p>
+          }
+          <p>
+            {{ 'Delete User' | translate }} <strong>{{ user?.username }}</strong>?
+          </p>
+          <p class="text-muted">{{ 'This action cannot be undone.' | translate }}</p>
+        </div>
+
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="btn btn-default"
+            (click)="cancel()"
+            [disabled]="loading"
+          >
+            {{ 'Cancel' | translate }}
+          </button>
+          <button
+            type="button"
+            class="btn btn-danger"
+            (click)="submit()"
+            [disabled]="loading"
+          >
+            @if (loading) {
+              <i class="fa fa-spinner fa-spin"></i>
+              {{ 'Deleting' | translate }}
+            } @else {
+              {{ 'Delete' | translate }}
+            }
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  @if (visible) {
+    <div class="modal-backdrop fade in"></div>
+  }
+</div>

--- a/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.less
+++ b/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.less
@@ -1,0 +1,47 @@
+@import 'variables';
+
+.modal {
+  display: block;
+
+  &.in {
+    opacity: 1;
+  }
+
+  .modal-dialog {
+    width: 50%;
+    min-width: 24rem;
+    max-width: 36rem;
+    margin: 10% auto;
+  }
+
+  .modal-header {
+    border-bottom: 0.0625rem solid @gray-light;
+
+    .modal-title {
+      font-size: @font-large;
+      font-weight: bold;
+    }
+
+    .close {
+      font-size: 1.25rem;
+      cursor: pointer;
+    }
+  }
+
+  .modal-body {
+    padding: 1.25rem;
+  }
+
+  .modal-footer {
+    border-top: 0.0625rem solid @gray-light;
+    text-align: right;
+
+    .btn {
+      margin-left: 0.3125rem;
+    }
+  }
+}
+
+.modal-backdrop {
+  opacity: 0.5;
+}

--- a/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.ts
@@ -35,7 +35,9 @@ export class DeleteUserComponent {
   }
 
   async submit() {
-    if (!this.user?.username) return;
+    if (!this.user?.username) {
+      return;
+    }
 
     this.loading = true;
     this.error = null;

--- a/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { DeleteUserService } from '@admin-tool-services/delete-user.service';
+import { UsersService } from '@admin-tool-services/users.service';
+import { User } from '@admin-tool-modules/users/users-interfaces';
+
+/**
+ * Confirmation modal for deleting a user.
+ * Controlled by the parent via the `visible` input and `user` input.
+ * Emits `closed` when dismissed and `userDeleted` on successful deletion.
+ */
+@Component({
+  selector: 'delete-user',
+  standalone: true,
+  imports: [TranslatePipe],
+  templateUrl: './delete-user.component.html',
+})
+export class DeleteUserComponent {
+  @Input() visible = false;
+  @Input() user: User | null = null;
+  @Output() closed = new EventEmitter<void>();
+  @Output() userDeleted = new EventEmitter<void>();
+
+  loading = false;
+  error: string | null = null;
+
+  constructor(
+    private deleteUserService: DeleteUserService,
+    private usersService: UsersService,
+  ) {}
+
+  cancel() {
+    this.error = null;
+    this.closed.emit();
+  }
+
+  async submit() {
+    if (!this.user?.username) return;
+
+    this.loading = true;
+    this.error = null;
+    try {
+      await this.deleteUserService.deleteUser(this.user.username);
+      this.usersService.notifyUsersUpdated();
+      this.userDeleted.emit();
+      this.closed.emit();
+    } catch (err: any) {
+      this.error = err?.error?.message || 'Error deleting document';
+    } finally {
+      this.loading = false;
+    }
+  }
+}

--- a/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/delete-user/delete-user.component.ts
@@ -14,6 +14,7 @@ import { User } from '@admin-tool-modules/users/users-interfaces';
   standalone: true,
   imports: [TranslatePipe],
   templateUrl: './delete-user.component.html',
+  styleUrl: './delete-user.component.less',
 })
 export class DeleteUserComponent {
   @Input() visible = false;
@@ -34,7 +35,7 @@ export class DeleteUserComponent {
     this.closed.emit();
   }
 
-  async submit() {
+  async confirm() {
     if (!this.user?.username) {
       return;
     }

--- a/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.html
@@ -1,0 +1,316 @@
+<div>
+  <div
+    class="modal fade"
+    [class.in]="visible"
+    [style.display]="visible ? 'block' : 'none'"
+    role="dialog"
+  >
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <!-- Header -->
+        <div class="modal-header">
+          <button
+            type="button"
+            class="close"
+            (click)="cancel()"
+            aria-label="Close"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title">{{ 'Edit User' | translate }}</h4>
+        </div>
+
+        <!-- Body -->
+        <div class="modal-body">
+          @if (errors.submit) {
+            <p class="alert alert-danger" role="alert">
+              {{ errors.submit | translate }}
+            </p>
+          }
+
+          @if (errors.replicationLimit) {
+            <p class="alert alert-warning" role="alert">
+              {{ errors.replicationLimit | translate }}
+            </p>
+          }
+
+          <!-- Username — read-only when editing -->
+          <div class="form-group">
+            <label for="username">{{ 'User Name' | translate }}</label>
+            <input
+              id="username"
+              type="text"
+              class="form-control"
+              [(ngModel)]="model.username"
+              disabled
+            />
+          </div>
+
+          <!-- Full Name -->
+          <div class="form-group">
+            <label for="fullname">{{ 'Full Name' | translate }}</label>
+            <input
+              id="fullname"
+              type="text"
+              class="form-control"
+              [(ngModel)]="model.fullname"
+            />
+            <span class="help-block text-muted">{{ 'user.fullname.help' | translate }}</span>
+          </div>
+
+          <!-- Email -->
+          <div class="form-group" [class.has-error]="errors.email">
+            <label for="email">{{ 'Email Address' | translate }}</label>
+            <input
+              id="email"
+              type="text"
+              class="form-control"
+              [(ngModel)]="model.email"
+            />
+            @if (errors.email) {
+              <span class="help-block">{{ errors.email | translate }}</span>
+            }
+          </div>
+
+          <!-- Phone -->
+          <div
+            class="form-group"
+            [class.required]="model.token_login"
+            [class.has-error]="errors.phone"
+          >
+            <label for="phone">{{ 'Phone Number' | translate }}</label>
+            <input
+              id="phone"
+              type="text"
+              class="form-control"
+              [(ngModel)]="model.phone"
+            />
+            <span class="help-block text-muted">{{ 'user.phone.help' | translate }}</span>
+            @if (errors.phone) {
+              <span class="help-block">{{ errors.phone | translate }}</span>
+            }
+          </div>
+
+          <!-- Roles -->
+          <div class="form-group required" [class.has-error]="errors.roles">
+            <label>{{ 'configuration.role' | translate }}</label> *
+            <ul class="list-unstyled">
+              @for (role of availableRoles; track role.key) {
+                <li class="checkbox">
+                  <label [for]="'role-' + role.key">
+                    <input
+                      type="checkbox"
+                      [id]="'role-' + role.key"
+                      [checked]="model.roles.indexOf(role.key) !== -1"
+                      (click)="toggleRole(role.key)"
+                    />
+                    {{ role.label | translate }}
+                  </label>
+                </li>
+              }
+            </ul>
+            @if (errors.roles) {
+              <span class="help-block">{{ errors.roles | translate }}</span>
+            }
+          </div>
+
+          <!-- Facility -->
+          <div
+            class="form-group"
+            [class.required]="isOfflineRole"
+            [class.has-error]="errors.place"
+          >
+            <label for="facility-select">{{ 'Facility' | translate }}</label>
+            <select
+              id="facility-select"
+              class="form-control"
+              #facilitySelect
+            ></select>
+            <span class="help-block text-muted">{{ 'user.place.help' | translate }}</span>
+            @if (errors.place) {
+              <span class="help-block">{{ errors.place | translate }}</span>
+            }
+          </div>
+
+          <!-- Associated Contact -->
+          <div
+            class="form-group"
+            [class.required]="isOfflineRole"
+            [class.has-error]="errors.contact"
+          >
+            <label for="contact-select">{{ 'associated.contact' | translate }}</label>
+            <span class="help-block text-muted">{{ 'associated.contact.help' | translate }}</span>
+            <select
+              id="contact-select"
+              class="form-control"
+              #contactSelect
+            ></select>
+            @if (errors.contact) {
+              <span class="help-block">{{ errors.contact | translate }}</span>
+            }
+          </div>
+
+          <!-- SSO Username -->
+          @if (allowSSOLogin && (model.tokenLoginEnabled && model.token_login === false || !model.tokenLoginEnabled && !model.token_login)) {
+            <div class="form-group">
+              <label for="sso-login">{{ 'user.sso.username' | translate }}</label>
+              <input
+                id="sso-login"
+                type="text"
+                class="form-control"
+                [(ngModel)]="model.oidc_username"
+              />
+              <span class="help-block text-muted">{{ 'user.sso.username.help' | translate }}</span>
+            </div>
+          }
+
+          <!-- Token Login — enable (when not currently enabled) -->
+          @if (allowTokenLogin && !model.tokenLoginEnabled && !(allowSSOLogin && model.oidc_username)) {
+            <div class="form-group">
+              <input
+                type="checkbox"
+                id="token-login"
+                [(ngModel)]="model.token_login"
+              />
+              <label for="token-login" class="form-check-label">
+                {{ 'configuration.enable.token.login' | translate }}
+              </label>
+              <div class="help-block text-muted">
+                {{ 'configuration.enable.token.login.help' | translate }}
+              </div>
+            </div>
+          }
+
+          <!-- Token Login — manage (when already enabled) -->
+          @if (allowTokenLogin && model.tokenLoginEnabled && !(allowSSOLogin && model.oidc_username)) {
+            <div class="form-group">
+              <p>
+                <label class="form-check-label">
+                  @if (model.tokenLoginEnabled.active && !model.tokenLoginEnabled.expired) {
+                    <span>{{ 'configuration.enable.token.login.enabled.active' | translate }}</span>
+                  } @else if (model.tokenLoginEnabled.active && model.tokenLoginEnabled.expired) {
+                    <span>{{ 'configuration.enable.token.login.enabled.expired' | translate }}</span>
+                  } @else {
+                    <span>{{ 'configuration.enable.token.login.enabled.inactive' | translate }}</span>
+                  }
+                </label>
+              </p>
+              <div>
+                <input
+                  type="radio"
+                  id="unmodified-token-login"
+                  [value]="null"
+                  [(ngModel)]="model.token_login"
+                />
+                <label for="unmodified-token-login" class="form-check-label">
+                  {{ 'configuration.enable.token.login.no.modify' | translate }}
+                </label>
+              </div>
+              <div>
+                <input
+                  type="radio"
+                  id="disable-token-login"
+                  [value]="false"
+                  [(ngModel)]="model.token_login"
+                />
+                <label for="disable-token-login" class="form-check-label">
+                  {{ 'configuration.enable.token.login.disable' | translate }}
+                </label>
+              </div>
+              <div>
+                <input
+                  type="radio"
+                  id="refresh-token-login"
+                  [value]="true"
+                  [(ngModel)]="model.token_login"
+                />
+                <label for="refresh-token-login" class="form-check-label">
+                  {{ 'configuration.enable.token.login.refresh' | translate }}
+                </label>
+              </div>
+              <div class="help-block text-muted">
+                {{ 'configuration.enable.token.login.refresh.help' | translate }}
+              </div>
+            </div>
+          }
+
+          <!-- Password — optional for existing users, hidden when token/SSO active -->
+          @if (!passwordHidden) {
+            <div class="form-group" [class.has-error]="errors.password">
+              <label for="password">{{ 'Password' | translate }}</label>
+              <div class="input-group">
+                <input
+                  id="password"
+                  [type]="model.showPassword ? 'text' : 'password'"
+                  class="form-control"
+                  [(ngModel)]="model.password"
+                  autocomplete="new-password"
+                />
+                <span class="input-group-btn">
+                  <button
+                    type="button"
+                    class="btn btn-default"
+                    (click)="togglePassword()"
+                    [attr.aria-label]="(model.showPassword ? 'password.hide' : 'password.show') | translate"
+                  >
+                    <i
+                      class="fa fa-eye"
+                      [class.fa-eye-slash]="model.showPassword"
+                    ></i>
+                  </button>
+                </span>
+              </div>
+              @if (errors.password) {
+                <span class="help-block">{{ errors.password | translate }}</span>
+              }
+            </div>
+
+            <!-- Confirm Password -->
+            <div class="form-group" [class.has-error]="errors.passwordConfirm">
+              <label for="password-confirm">{{ 'Confirm Password' | translate }}</label>
+              <input
+                id="password-confirm"
+                [type]="model.showPassword ? 'text' : 'password'"
+                class="form-control"
+                [(ngModel)]="model.passwordConfirm"
+                autocomplete="new-password"
+              />
+              @if (errors.passwordConfirm) {
+                <span class="help-block">{{ errors.passwordConfirm | translate }}</span>
+              }
+            </div>
+          }
+        </div>
+
+        <!-- Footer -->
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="btn btn-default"
+            (click)="cancel()"
+            [disabled]="loading"
+          >
+            {{ 'Cancel' | translate }}
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="submit()"
+            [disabled]="loading"
+          >
+            @if (loading) {
+              <i class="fa fa-spinner fa-spin"></i>
+              {{ 'Submitting' | translate }}
+            } @else {
+              {{ 'Submit' | translate }}
+            }
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  @if (visible) {
+    <div class="modal-backdrop fade in"></div>
+  }
+</div>

--- a/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.html
@@ -151,7 +151,7 @@
           </div>
 
           <!-- SSO Username -->
-          @if (allowSSOLogin && (model.tokenLoginEnabled && model.token_login === false || !model.tokenLoginEnabled && !model.token_login)) {
+          @if (allowSSOLogin && !model.token_login) {
             <div class="form-group">
               <label for="sso-login">{{ 'user.sso.username' | translate }}</label>
               <input

--- a/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.less
+++ b/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.less
@@ -1,0 +1,98 @@
+@import 'variables';
+
+.modal {
+  &.in {
+    opacity: 1;
+  }
+
+  .modal-header {
+    border-bottom: 0.0625rem solid @gray-light;
+
+    .modal-title {
+      font-size: @font-large;
+      font-weight: bold;
+    }
+
+    .close {
+      font-size: 1.25rem;
+      cursor: pointer;
+    }
+  }
+
+  .modal-body {
+    padding: 1.25rem;
+    max-height: 28rem;
+    overflow-y: auto;
+
+    .form-group {
+      margin-bottom: 0.9375rem;
+
+      label {
+        font-weight: bold;
+        margin-bottom: 0.3125rem;
+        display: block;
+      }
+
+      &.required label::after {
+        content: ' *';
+        color: @red;
+      }
+
+      &.has-error {
+        .form-control {
+          border-color: @red;
+        }
+
+        .help-block {
+          color: @red;
+        }
+      }
+
+      .help-block {
+        font-size: 0.75rem;
+        margin-top: 0.25rem;
+        display: block;
+      }
+
+      .list-unstyled {
+        margin: 0;
+
+        .checkbox {
+          margin: 0.3125rem 0;
+
+          label {
+            font-weight: normal;
+            cursor: pointer;
+
+            input[type='checkbox'] {
+              margin-right: 0.375rem;
+            }
+          }
+        }
+      }
+
+      .input-group {
+        .btn-default {
+          border-color: @gray-light;
+
+          &:hover {
+            background-color: @gray-ultra-lighter;
+          }
+        }
+      }
+    }
+  }
+
+  .modal-footer {
+    border-top: 0.0625rem solid @gray-light;
+    text-align: right;
+
+    .btn {
+      margin-left: 0.3125rem;
+    }
+  }
+}
+
+.modal-backdrop {
+  opacity: 0.5;
+}

--- a/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.less
+++ b/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.less
@@ -1,8 +1,17 @@
 @import 'variables';
 
 .modal {
+  display: block;
+
   &.in {
     opacity: 1;
+  }
+
+  .modal-dialog {
+    width: 50%;
+    min-width: 30rem;
+    max-width: 50rem;
+    margin: 5% auto;
   }
 
   .modal-header {

--- a/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.ts
@@ -150,7 +150,9 @@ export class EditUserComponent implements OnChanges {
   }
 
   private populateModel() {
-    if (!this.user) return;
+    if (!this.user) {
+      return;
+    }
 
     const facilityId = this.user.facility_id
       ? Array.isArray(this.user.facility_id)
@@ -161,15 +163,15 @@ export class EditUserComponent implements OnChanges {
     const tokenLoginData = (this.user as any).token_login;
     const tokenLoginEnabled = tokenLoginData
       ? {
-          active: tokenLoginData.active,
-          expired: tokenLoginData.expiration_date <= new Date().getTime(),
-          expirationDate: tokenLoginData.expiration_date
-            ? new Date(tokenLoginData.expiration_date).toLocaleDateString()
-            : '',
-          loginDate: tokenLoginData.login_date
-            ? new Date(tokenLoginData.login_date).toLocaleDateString()
-            : undefined,
-        }
+        active: tokenLoginData.active,
+        expired: tokenLoginData.expiration_date <= new Date().getTime(),
+        expirationDate: tokenLoginData.expiration_date
+          ? new Date(tokenLoginData.expiration_date).toLocaleDateString()
+          : '',
+        loginDate: tokenLoginData.login_date
+          ? new Date(tokenLoginData.login_date).toLocaleDateString()
+          : undefined,
+      }
       : null;
 
     this.model = {
@@ -195,8 +197,12 @@ export class EditUserComponent implements OnChanges {
   }
 
   private filterRoles(roles: string[]): string[] {
-    if (!roles.length) return [];
-    if (roles.includes('_admin')) return ['_admin'];
+    if (!roles.length) {
+      return [];
+    }
+    if (roles.includes('_admin')) {
+      return ['_admin'];
+    }
     return roles.filter(role => !!this.settingsRoles[role]);
   }
 
@@ -281,7 +287,9 @@ export class EditUserComponent implements OnChanges {
   }
 
   private validatePhone() {
-    if (!this.model.token_login) return;
+    if (!this.model.token_login) {
+      return;
+    }
     if (!this.model.phone) {
       this.errors.phone = 'field.required';
     } else if (!phoneNumber.validate(this.cachedSettings, this.model.phone)) {
@@ -291,8 +299,12 @@ export class EditUserComponent implements OnChanges {
 
   private validateFacilityAndContact() {
     if (this.isOfflineUser()) {
-      if (!this.model.place) this.errors.place = 'field.required';
-      if (!this.model.contact) this.errors.contact = 'field.required';
+      if (!this.model.place) {
+        this.errors.place = 'field.required';
+      }
+      if (!this.model.contact) {
+        this.errors.contact = 'field.required';
+      }
     } else if (this.model.contact && !this.model.place) {
       this.errors.place = 'field.required';
     }
@@ -350,18 +362,24 @@ export class EditUserComponent implements OnChanges {
   }
 
   private async validateContactInPlace(): Promise<boolean> {
-    if (!this.isOfflineUser() || !this.model.contact || !this.model.place) return true;
+    if (!this.isOfflineUser() || !this.model.contact || !this.model.place) {
+      return true;
+    }
 
     const placeIds = Array.isArray(this.model.place) ? this.model.place : [this.model.place];
     const valid = await this.select2SearchService.isContactInPlace(this.model.contact, placeIds);
 
-    if (!valid) this.errors.contact = 'configuration.user.place.contact';
+    if (!valid) {
+      this.errors.contact = 'configuration.user.place.contact';
+    }
 
     return valid;
   }
 
   private async validateReplicationLimit(): Promise<boolean> {
-    if (!this.isOfflineUser()) return true;
+    if (!this.isOfflineUser()) {
+      return true;
+    }
 
     try {
       const params: any = {
@@ -392,10 +410,14 @@ export class EditUserComponent implements OnChanges {
     const updates: Record<string, any> = {};
 
     for (const key of Object.keys(this.model) as (keyof EditUserModel)[]) {
-      if (key === 'id' || FIELDS_TO_IGNORE.includes(key)) continue;
+      if (key === 'id' || FIELDS_TO_IGNORE.includes(key)) {
+        continue;
+      }
 
       if (key === 'password') {
-        if (this.model.password) updates.password = this.model.password;
+        if (this.model.password) {
+          updates.password = this.model.password;
+        }
         continue;
       }
 
@@ -441,13 +463,19 @@ export class EditUserComponent implements OnChanges {
   async submit() {
     this.computeFields();
 
-    if (!this.validate()) return;
+    if (!this.validate()) {
+      return;
+    }
 
     const contactValid = await this.validateContactInPlace();
-    if (!contactValid) return;
+    if (!contactValid) {
+      return;
+    }
 
     const withinLimit = await this.validateReplicationLimit();
-    if (!withinLimit) return;
+    if (!withinLimit) {
+      return;
+    }
 
     const updates = this.getChangedUpdates();
     if (!Object.keys(updates).length) {

--- a/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.ts
@@ -1,0 +1,474 @@
+import {
+  Component, Input, Output, EventEmitter,
+  OnChanges, SimpleChanges,
+  ViewChild, ElementRef
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { TranslatePipe } from '@ngx-translate/core';
+import { EditUserService } from '@admin-tool-services/edit-user.service';
+import { Select2SearchService } from '@admin-tool-services/select2search.service';
+import { SettingsService } from '@admin-tool-services/settings.service';
+import { UsersService } from '@admin-tool-services/users.service';
+import { User } from '@admin-tool-modules/users/users-interfaces';
+
+const passwordTester = require('simple-password-tester');
+const phoneNumber = require('@medic/phone-number');
+const PASSWORD_MINIMUM_LENGTH = 8;
+const PASSWORD_MINIMUM_SCORE = 50;
+
+const FIELDS_TO_IGNORE = [
+  'passwordConfirm',
+  'showPassword',
+  'tokenLoginEnabled',
+];
+
+export interface EditUserErrors {
+  username?: string;
+  fullname?: string;
+  email?: string;
+  phone?: string;
+  roles?: string;
+  place?: string;
+  contact?: string;
+  password?: string;
+  passwordConfirm?: string;
+  submit?: string;
+  replicationLimit?: string;
+}
+
+export interface EditUserModel {
+  id: string;
+  username: string;
+  fullname: string;
+  email: string;
+  phone: string;
+  roles: string[];
+  place: string | string[] | null;
+  contact: string | null;
+  token_login: boolean | '' | null;
+  tokenLoginEnabled: {
+    active: boolean;
+    expired: boolean;
+    expirationDate: string;
+    loginDate?: string;
+  } | null;
+  oidc_username: string;
+  password: string;
+  passwordConfirm: string;
+  showPassword: boolean;
+}
+
+const getInitialModel = (): EditUserModel => ({
+  id: '',
+  username: '',
+  fullname: '',
+  email: '',
+  phone: '',
+  roles: [],
+  place: null,
+  contact: null,
+  token_login: null,
+  tokenLoginEnabled: null,
+  oidc_username: '',
+  password: '',
+  passwordConfirm: '',
+  showPassword: false,
+});
+
+/**
+ * Modal component for editing an existing user.
+ * Controlled by the parent via the `visible` and `user` inputs.
+ * Emits `closed` when dismissed and `userUpdated` on successful update.
+ */
+@Component({
+  selector: 'edit-user',
+  standalone: true,
+  imports: [FormsModule, TranslatePipe],
+  templateUrl: './edit-user.component.html',
+  styleUrl: './edit-user.component.less',
+})
+export class EditUserComponent implements OnChanges {
+  @Input() visible = false;
+  @Input() user: User | null = null;
+  @Output() closed = new EventEmitter<void>();
+  @Output() userUpdated = new EventEmitter<void>();
+
+  @ViewChild('facilitySelect') facilitySelectRef!: ElementRef<HTMLSelectElement>;
+  @ViewChild('contactSelect') contactSelectRef!: ElementRef<HTMLSelectElement>;
+
+  loading = false;
+  errors: EditUserErrors = {};
+  availableRoles: { key: string; label: string }[] = [];
+  isOfflineRole = false;
+  allowTokenLogin = false;
+  allowSSOLogin = false;
+
+  model: EditUserModel = getInitialModel();
+
+  private settingsRoles: Record<string, { name: string; offline?: boolean }> = {};
+  private cachedSettings: any = null;
+  private originalModel: EditUserModel = getInitialModel();
+
+  constructor(
+    private editUserService: EditUserService,
+    private http: HttpClient,
+    private select2SearchService: Select2SearchService,
+    private settingsService: SettingsService,
+    private usersService: UsersService,
+  ) {}
+
+  /**
+   * When the modal becomes visible and a user is provided, load settings
+   * and populate the model from the user object.
+   */
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['visible']?.currentValue === true && this.user) {
+      this.loadSettingsAndPopulate();
+    }
+    if (changes['visible']?.currentValue === false) {
+      this.reset();
+    }
+  }
+
+  async loadSettingsAndPopulate() {
+    try {
+      this.cachedSettings = await this.settingsService.get();
+      this.settingsRoles = this.cachedSettings.roles ?? {};
+      this.availableRoles = Object.entries(this.settingsRoles)
+        .filter(([key]) => key !== '_admin')
+        .map(([key, role]: [string, any]) => ({ key, label: role.name }));
+      this.allowTokenLogin = !!this.cachedSettings.token_login?.enabled;
+      this.allowSSOLogin = !!this.cachedSettings.oidc_provider;
+      this.populateModel();
+      // Defer Select2 init to next tick so modal DOM is rendered
+      setTimeout(() => this.initSelect2(), 0);
+    } catch (err) {
+      console.error('Error loading settings', err);
+    }
+  }
+
+  private populateModel() {
+    if (!this.user) return;
+
+    const facilityId = this.user.facility_id
+      ? Array.isArray(this.user.facility_id)
+        ? this.user.facility_id
+        : [this.user.facility_id]
+      : null;
+
+    const tokenLoginData = (this.user as any).token_login;
+    const tokenLoginEnabled = tokenLoginData
+      ? {
+          active: tokenLoginData.active,
+          expired: tokenLoginData.expiration_date <= new Date().getTime(),
+          expirationDate: tokenLoginData.expiration_date
+            ? new Date(tokenLoginData.expiration_date).toLocaleDateString()
+            : '',
+          loginDate: tokenLoginData.login_date
+            ? new Date(tokenLoginData.login_date).toLocaleDateString()
+            : undefined,
+        }
+      : null;
+
+    this.model = {
+      id: this.user.id || '',
+      username: this.user.username || '',
+      fullname: this.user.fullname || '',
+      email: (this.user as any).email || '',
+      phone: this.user.phone || '',
+      roles: this.filterRoles(this.user.roles || []),
+      place: facilityId,
+      contact: this.user.contact_id || null,
+      token_login: null,
+      tokenLoginEnabled,
+      oidc_username: (this.user as any).oidc_username || '',
+      password: '',
+      passwordConfirm: '',
+      showPassword: false,
+    };
+
+    // Store original for diffing changed fields on submit
+    this.originalModel = { ...this.model, roles: [...this.model.roles] };
+    this.isOfflineRole = this.isOfflineUser();
+  }
+
+  private filterRoles(roles: string[]): string[] {
+    if (!roles.length) return [];
+    if (roles.includes('_admin')) return ['_admin'];
+    return roles.filter(role => !!this.settingsRoles[role]);
+  }
+
+  private async initSelect2() {
+    if (this.facilitySelectRef?.nativeElement) {
+      // initialValue accepts a single string — preselect the first place if multiple
+      const placeIds = Array.isArray(this.model.place)
+        ? this.model.place
+        : this.model.place ? [this.model.place] : [];
+      const initialValue = placeIds[0] || undefined;
+      await this.select2SearchService.initPlaceSelect(
+        this.facilitySelectRef.nativeElement,
+        { initialValue }
+      );
+    }
+    if (this.contactSelectRef?.nativeElement) {
+      const initialValue = this.model.contact || undefined;
+      await this.select2SearchService.initPersonSelect(
+        this.contactSelectRef.nativeElement,
+        { initialValue }
+      );
+    }
+  }
+
+  private computeFields() {
+    if (this.facilitySelectRef?.nativeElement) {
+      const val = $(this.facilitySelectRef.nativeElement).val();
+      if (typeof val === 'string' || Array.isArray(val)) {
+        this.model.place = Array.isArray(val) && val.length === 0 ? null : val as string;
+      }
+    }
+    if (this.contactSelectRef?.nativeElement) {
+      const val = $(this.contactSelectRef.nativeElement).val();
+      if (typeof val === 'string') {
+        this.model.contact = val || null;
+      }
+    }
+  }
+
+  private isOfflineUser(): boolean {
+    return this.model.roles.some(role => this.settingsRoles[role]?.offline === true);
+  }
+
+  get passwordHidden(): boolean {
+    return (this.allowTokenLogin && (
+      !!this.model.token_login ||
+      (this.model.token_login !== false && !!this.model.tokenLoginEnabled)
+    )) || (this.allowSSOLogin && !!this.model.oidc_username);
+  }
+
+  cancel() {
+    this.reset();
+    this.closed.emit();
+  }
+
+  togglePassword() {
+    this.model.showPassword = !this.model.showPassword;
+  }
+
+  toggleRole(key: string) {
+    const index = this.model.roles.indexOf(key);
+    if (index === -1) {
+      this.model.roles.push(key);
+    } else {
+      this.model.roles.splice(index, 1);
+    }
+    this.isOfflineRole = this.isOfflineUser();
+  }
+
+  // --- Validation sub-methods ---
+
+  private validateEmail() {
+    if (this.model.email && !/^[^\s@]+@[^\s@]+$/.test(this.model.email)) {
+      this.errors.email = 'email.invalid';
+    }
+  }
+
+  private validateRoles() {
+    if (!this.model.roles.length) {
+      this.errors.roles = 'field.required';
+    }
+  }
+
+  private validatePhone() {
+    if (!this.model.token_login) return;
+    if (!this.model.phone) {
+      this.errors.phone = 'field.required';
+    } else if (!phoneNumber.validate(this.cachedSettings, this.model.phone)) {
+      this.errors.phone = 'configuration.enable.token.login.phone';
+    }
+  }
+
+  private validateFacilityAndContact() {
+    if (this.isOfflineUser()) {
+      if (!this.model.place) this.errors.place = 'field.required';
+      if (!this.model.contact) this.errors.contact = 'field.required';
+    } else if (this.model.contact && !this.model.place) {
+      this.errors.place = 'field.required';
+    }
+  }
+
+  /**
+   * Password validation for edit differs from create:
+   * - If token login or SSO is active, clear and skip password fields
+   * - If disabling token login (token_login === false), password is required
+   * - For existing users, password is optional — only validate if either field is filled
+   */
+  private validatePassword() {
+    if (this.passwordHidden) {
+      this.model.password = '';
+      this.model.passwordConfirm = '';
+      return;
+    }
+
+    const disablingTokenLogin = this.model.token_login === false;
+    const eitherFieldFilled = this.model.password || this.model.passwordConfirm;
+
+    if (!disablingTokenLogin && !eitherFieldFilled) {
+      // Existing user, no password change — skip validation
+      return;
+    }
+
+    if (!this.model.password) {
+      this.errors.password = 'field.required';
+      return;
+    }
+
+    if (this.model.password.length < PASSWORD_MINIMUM_LENGTH) {
+      this.errors.password = 'password.length.minimum';
+      return;
+    }
+
+    if (passwordTester(this.model.password) < PASSWORD_MINIMUM_SCORE) {
+      this.errors.password = 'password.weak';
+      return;
+    }
+
+    if (this.model.password !== this.model.passwordConfirm) {
+      this.errors.passwordConfirm = 'Passwords must match';
+    }
+  }
+
+  private validate(): boolean {
+    this.errors = {};
+    this.validateEmail();
+    this.validateRoles();
+    this.validatePhone();
+    this.validateFacilityAndContact();
+    this.validatePassword();
+    return Object.keys(this.errors).length === 0;
+  }
+
+  private async validateContactInPlace(): Promise<boolean> {
+    if (!this.isOfflineUser() || !this.model.contact || !this.model.place) return true;
+
+    const placeIds = Array.isArray(this.model.place) ? this.model.place : [this.model.place];
+    const valid = await this.select2SearchService.isContactInPlace(this.model.contact, placeIds);
+
+    if (!valid) this.errors.contact = 'configuration.user.place.contact';
+
+    return valid;
+  }
+
+  private async validateReplicationLimit(): Promise<boolean> {
+    if (!this.isOfflineUser()) return true;
+
+    try {
+      const params: any = {
+        role: this.model.roles,
+        facility_id: this.model.place,
+        contact_id: this.model.contact,
+      };
+      const resp: any = await firstValueFrom(
+        this.http.get('/api/v1/users-info', { params })
+      );
+      if (resp?.warn) {
+        this.errors.replicationLimit = 'configuration.user.replication.limit.exceeded';
+        return false;
+      }
+    } catch (err) {
+      console.error('Error checking replication limit', err);
+    }
+
+    return true;
+  }
+
+  /**
+   * Returns only the fields that have changed compared to the original model.
+   * Password is included only if non-empty.
+   * Internal/meta fields are excluded.
+   */
+  private getChangedUpdates(): Record<string, any> {
+    const updates: Record<string, any> = {};
+
+    for (const key of Object.keys(this.model) as (keyof EditUserModel)[]) {
+      if (key === 'id' || FIELDS_TO_IGNORE.includes(key)) continue;
+
+      if (key === 'password') {
+        if (this.model.password) updates.password = this.model.password;
+        continue;
+      }
+
+      if (key === 'roles') {
+        const updated = [...this.model.roles].sort();
+        const original = [...this.originalModel.roles].sort();
+        if (
+          updated.length !== original.length ||
+          !updated.every((r, i) => r === original[i])
+        ) {
+          updates.roles = this.model.roles;
+        }
+        continue;
+      }
+
+      if (this.model[key] !== this.originalModel[key]) {
+        updates[key] = this.model[key];
+      }
+    }
+
+    return updates;
+  }
+
+  private reset() {
+    this.model = getInitialModel();
+    this.originalModel = getInitialModel();
+    this.errors = {};
+    this.loading = false;
+    this.isOfflineRole = false;
+
+    if (this.facilitySelectRef?.nativeElement) {
+      const $facility = $(this.facilitySelectRef.nativeElement);
+      $facility.val([]);
+      $facility.trigger('change');
+    }
+    if (this.contactSelectRef?.nativeElement) {
+      const $contact = $(this.contactSelectRef.nativeElement);
+      $contact.val('');
+      $contact.trigger('change');
+    }
+  }
+
+  async submit() {
+    this.computeFields();
+
+    if (!this.validate()) return;
+
+    const contactValid = await this.validateContactInPlace();
+    if (!contactValid) return;
+
+    const withinLimit = await this.validateReplicationLimit();
+    if (!withinLimit) return;
+
+    const updates = this.getChangedUpdates();
+    if (!Object.keys(updates).length) {
+      // Nothing changed — just close
+      this.reset();
+      this.closed.emit();
+      return;
+    }
+
+    this.loading = true;
+    this.errors = {};
+    try {
+      await this.editUserService.updateUser(this.model.username, updates);
+      this.usersService.notifyUsersUpdated();
+      this.reset();
+      this.userUpdated.emit();
+      this.closed.emit();
+    } catch (err: any) {
+      this.errors.submit = err?.error?.message || 'Error updating user';
+    } finally {
+      this.loading = false;
+    }
+  }
+}

--- a/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.html
@@ -58,6 +58,7 @@
                     <button
                       class="btn btn-sm btn-danger"
                       (click)="deleteUser(user, $event)"
+                      [attr.aria-label]="'Delete user' | translate"
                     >
                       <i class="fa fa-trash-o"></i>
                     </button>
@@ -75,5 +76,19 @@
       (closed)="showCreateModal = false"
       (userCreated)="showCreateModal = false"
     ></create-user>
+
+    <edit-user
+      [visible]="showEditModal"
+      [user]="selectedUser"
+      (closed)="showEditModal = false"
+      (userUpdated)="showEditModal = false"
+    ></edit-user>
+
+    <delete-user
+      [visible]="showDeleteModal"
+      [user]="selectedUser"
+      (closed)="showDeleteModal = false"
+      (userDeleted)="showDeleteModal = false"
+    ></delete-user>
   }
 </div>

--- a/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.ts
@@ -1,20 +1,22 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { TranslatePipe } from '@ngx-translate/core';
 import { AuthService } from '@admin-tool-services/auth.service';
 import { UsersService } from '@admin-tool-services/users.service';
 import { User } from '@admin-tool-modules/users/users-interfaces';
 import { CreateUserComponent } from '../create-user/create-user.component';
+import { EditUserComponent } from '../edit-user/edit-user.component';
+import { DeleteUserComponent } from '../delete-user/delete-user.component';
+
 /**
  * Displays and manages the list of system users.
- * Requires `can_configure` permission to access — unauthorized users see an error message.
- * Fetches users from the API on initialization and provides hooks for create, edit, and delete actions.
+ * Requires `can_configure` permission to access.
+ * Provides hooks for create, edit, and delete actions via modal components.
  */
 @Component({
   selector: 'users-list',
   standalone: true,
-  imports: [CommonModule, CreateUserComponent, TranslatePipe],
+  imports: [TranslatePipe, CreateUserComponent, EditUserComponent, DeleteUserComponent],
   templateUrl: './users-list.component.html',
   styleUrl: './users-list.component.less',
 })
@@ -23,7 +25,12 @@ export class UsersListComponent implements OnInit, OnDestroy {
   loading = false;
   error = false;
   users: Partial<User>[] = [];
+
   showCreateModal = false;
+  showEditModal = false;
+  showDeleteModal = false;
+
+  selectedUser: Partial<User> | null = null;
 
   private usersUpdatedSubscription!: Subscription;
 
@@ -41,9 +48,7 @@ export class UsersListComponent implements OnInit, OnDestroy {
     });
 
     this.usersUpdatedSubscription = this.usersService.usersUpdated$.subscribe(
-      () => {
-        this.loadUsers();
-      },
+      () => this.loadUsers()
     );
   }
 
@@ -51,10 +56,6 @@ export class UsersListComponent implements OnInit, OnDestroy {
     this.usersUpdatedSubscription?.unsubscribe();
   }
 
-  /**
-   * Fetches the full list of users from the API.
-   * Sets `loading` during the request and `error` if the request fails.
-   */
   private async loadUsers() {
     this.loading = true;
     try {
@@ -67,50 +68,28 @@ export class UsersListComponent implements OnInit, OnDestroy {
     }
   }
 
-  /**
-   * Handles row click events — opens the edit modal for active users.
-   * Inactive users are ignored to prevent accidental edits on deleted accounts.
-   * @param user the user object from the row that was clicked
-   */
   onRowClick(user: Partial<User>) {
     if (!user.inactive) {
       this.editUser(user);
     }
   }
 
-  /**
-   * Opens the Add User modal.
-   */
   addUser() {
     this.showCreateModal = true;
   }
 
-  /**
-   * Opens the Import Users modal for bulk CSV upload.
-   * TODO: implement when the modal component is available.
-   */
   importUsers() {
     console.log('import users');
   }
 
-  /**
-   * Opens the Delete User confirmation modal.
-   * Stops event propagation to prevent triggering the row click handler.
-   * TODO: implement when the modal component is available.
-   * @param user the user to be deleted
-   * @param event the DOM click event
-   */
-  deleteUser(user: Partial<User>, event: Event) {
-    event.stopPropagation();
-    console.log('delete user', user);
+  editUser(user: Partial<User>) {
+    this.selectedUser = user;
+    this.showEditModal = true;
   }
 
-  /**
-   * Opens the Edit User modal for the given user.
-   * TODO: implement when the modal component is available.
-   * @param user the user to be edited
-   */
-  editUser(user: Partial<User>) {
-    console.log('edit user', user);
+  deleteUser(user: Partial<User>, event: Event) {
+    event.stopPropagation();
+    this.selectedUser = user;
+    this.showDeleteModal = true;
   }
 }

--- a/admin-tool/src/ts/modules/users/users-interfaces.ts
+++ b/admin-tool/src/ts/modules/users/users-interfaces.ts
@@ -5,19 +5,25 @@ export interface User {
   id?: string;
   username?: string;
   fullname?: string;
+  email?: string;
   phone?: string;
-  facility_id?: string;
+  facility_id?: string | string[];
   contact_id?: string;
   inactive?: boolean;
   roles?: string[];
+  token_login?: {
+    active: boolean;
+    expiration_date: number;
+    login_date?: number;
+  };
 }
 
 /**
- * Represents the validation error state for the Create User form.
+ * Validation errors for the Create User form.
  */
 export interface CreateUserErrors {
-  submit?: string;
   username?: string;
+  fullname?: string;
   email?: string;
   phone?: string;
   roles?: string;
@@ -25,5 +31,6 @@ export interface CreateUserErrors {
   contact?: string;
   password?: string;
   passwordConfirm?: string;
+  submit?: string;
   replicationLimit?: string;
 }

--- a/admin-tool/src/ts/services/delete-user.service.ts
+++ b/admin-tool/src/ts/services/delete-user.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+/**
+ * Service responsible for deleting a user via the CHT API.
+ *
+ * Wraps DELETE /api/v1/users/:username.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class DeleteUserService {
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Deletes a user by username.
+   *
+   * @param username - the username of the user to delete (without org.couchdb.user: prefix)
+   */
+  deleteUser(username: string): Promise<void> {
+    return firstValueFrom(
+      this.http.delete<void>(`/api/v1/users/${username}`)
+    );
+  }
+}

--- a/admin-tool/src/ts/services/edit-user.service.ts
+++ b/admin-tool/src/ts/services/edit-user.service.ts
@@ -1,0 +1,28 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+/**
+ * Service responsible for updating an existing user via the CHT API.
+ *
+ * Wraps POST /api/v1/users/:username — only the fields that have changed
+ * need to be included in the updates payload.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class EditUserService {
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Sends a partial update for an existing user.
+   *
+   * @param username - the username of the user to update (without org.couchdb.user: prefix)
+   * @param updates - the fields to update
+   */
+  updateUser(username: string, updates: Record<string, any>): Promise<void> {
+    return firstValueFrom(
+      this.http.post<void>(`/api/v1/users/${username}`, updates)
+    );
+  }
+}

--- a/admin-tool/src/ts/services/users.service.ts
+++ b/admin-tool/src/ts/services/users.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { firstValueFrom, BehaviorSubject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
+import { DbService } from '@admin-tool-services/db.service';
 import { User } from '@admin-tool-modules/users/users-interfaces';
 
 /**
- * Handles all HTTP communication with the users API endpoints.
+ * Handles fetching and updating users.
  * Exposes a shared observable to notify other components when the user list should be refreshed.
- * Credentials are sent automatically via the browser cookie on each request,
- * so no manual authentication headers are required.
+ *
+ * Uses the medic-client/doc_by_type CouchDB view directly (same as the AngularJS app) so that
+ * inactive (deleted) users are included in the list and shown as greyed out.
+ * The API endpoints (v1/users, v2/users) do not return inactive users.
  */
 @Injectable({
   providedIn: 'root',
@@ -21,14 +23,32 @@ export class UsersService {
    */
   usersUpdated$ = this.usersUpdatedSubject.asObservable();
 
-  constructor(private http: HttpClient) {}
+  constructor(private db: DbService) {}
 
   /**
-   * Fetches the full list of users from the API.
-   * @returns a promise that resolves to an array of user objects
+   * Fetches the full list of users from the CouchDB view, including inactive (deleted) users.
+   * Inactive users have `inactive: true` and are displayed as greyed out in the list.
+   * @returns a promise that resolves to an array of user-settings documents
    */
   async getUsers(): Promise<Partial<User>[]> {
-    return firstValueFrom(this.http.get<Partial<User>[]>('/api/v2/users'));
+    const result = await this.db.get().query('medic-client/doc_by_type', {
+      include_docs: true,
+      key: ['user-settings'],
+    });
+    return result.rows
+      .map((row: any) => row.doc)
+      .filter(Boolean)
+      .map((doc: any): Partial<User> => ({
+        id: doc._id,
+        username: doc.name,
+        fullname: doc.fullname,
+        email: doc.email,
+        phone: doc.phone,
+        facility_id: doc.facility_id,
+        contact_id: doc.contact_id,
+        roles: doc.roles,
+        inactive: doc.inactive,
+      }));
   }
 
   /**

--- a/admin-tool/tests/karma/ts/modules/users/delete-user.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/users/delete-user.component.spec.ts
@@ -102,7 +102,7 @@ describe('DeleteUserComponent', () => {
   });
 
   describe('Interface', () => {
-    it('should emit closed when cancel is called', async () => {
+    it('should emit closed when cancel is called', () => {
       const closedSpy = sinon.spy();
       component.closed.subscribe(closedSpy);
       component.cancel();

--- a/admin-tool/tests/karma/ts/modules/users/delete-user.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/users/delete-user.component.spec.ts
@@ -1,0 +1,223 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { TranslateModule } from '@ngx-translate/core';
+import { DeleteUserComponent } from '@admin-tool-modules/users/ts/components/delete-user/delete-user.component';
+import { DeleteUserService } from '@admin-tool-services/delete-user.service';
+import { UsersService } from '@admin-tool-services/users.service';
+import { User } from '@admin-tool-modules/users/users-interfaces';
+
+describe('DeleteUserComponent', () => {
+  let component: DeleteUserComponent;
+  let fixture: ComponentFixture<DeleteUserComponent>;
+  let deleteUserService: any;
+  let usersService: any;
+
+  const mockUser: Partial<User> = {
+    id: '1',
+    username: 'b_wayne',
+    fullname: 'Bruce Wayne',
+  };
+
+  const stabilize = async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    deleteUserService = { deleteUser: sinon.stub() };
+    usersService = { notifyUsersUpdated: sinon.stub() };
+
+    await TestBed.configureTestingModule({
+      imports: [DeleteUserComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: DeleteUserService, useValue: deleteUserService },
+        { provide: UsersService, useValue: usersService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeleteUserComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('Zero', () => {
+    it('should initialise with visible false', () => {
+      expect(component.visible).to.equal(false);
+    });
+
+    it('should initialise with no user', () => {
+      expect(component.user).to.be.null;
+    });
+
+    it('should initialise with loading false', () => {
+      expect(component.loading).to.equal(false);
+    });
+
+    it('should initialise with no error', () => {
+      expect(component.error).to.be.null;
+    });
+  });
+
+  describe('One', () => {
+    it('should show the modal when visible is true', async () => {
+      component.visible = true;
+      component.user = mockUser as User;
+      await stabilize();
+      const modal = fixture.nativeElement.querySelector('.modal.in');
+      expect(modal).to.exist;
+    });
+
+    it('should hide the modal when visible is false', async () => {
+      component.visible = false;
+      await stabilize();
+      const modal = fixture.nativeElement.querySelector('.modal.in');
+      expect(modal).to.not.exist;
+    });
+
+    it('should display the username in the confirmation message', async () => {
+      component.visible = true;
+      component.user = mockUser as User;
+      await stabilize();
+      const body = fixture.nativeElement.querySelector('.modal-body');
+      expect(body.textContent).to.include('b_wayne'); // username rendered directly, not through translate pipe
+    });
+  });
+
+  describe('Boundaries', () => {
+    it('should not call deleteUser when user has no username', async () => {
+      component.user = { id: '1' } as User;
+      await component.submit();
+      expect(deleteUserService.deleteUser.callCount).to.equal(0);
+    });
+
+    it('should not call deleteUser when user is null', async () => {
+      component.user = null;
+      await component.submit();
+      expect(deleteUserService.deleteUser.callCount).to.equal(0);
+    });
+  });
+
+  describe('Interface', () => {
+    it('should emit closed when cancel is called', async () => {
+      const closedSpy = sinon.spy();
+      component.closed.subscribe(closedSpy);
+      component.cancel();
+      expect(closedSpy.callCount).to.equal(1);
+    });
+
+    it('should clear error when cancel is called', () => {
+      component.error = 'some error';
+      component.cancel();
+      expect(component.error).to.be.null;
+    });
+
+    it('should call deleteUser with the username on submit', async () => {
+      component.user = mockUser as User;
+      deleteUserService.deleteUser.resolves({});
+      await stabilize();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await component.submit();
+
+      expect(deleteUserService.deleteUser.calledWith('b_wayne')).to.be.true;
+    });
+
+    it('should notify usersService after successful delete', async () => {
+      component.user = mockUser as User;
+      deleteUserService.deleteUser.resolves({});
+      await stabilize();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await component.submit();
+
+      expect(usersService.notifyUsersUpdated.callCount).to.equal(1);
+    });
+
+    it('should emit userDeleted and closed after successful delete', async () => {
+      const userDeletedSpy = sinon.spy();
+      const closedSpy = sinon.spy();
+      component.userDeleted.subscribe(userDeletedSpy);
+      component.closed.subscribe(closedSpy);
+      component.user = mockUser as User;
+      deleteUserService.deleteUser.resolves({});
+      await stabilize();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await component.submit();
+
+      expect(userDeletedSpy.callCount).to.equal(1);
+      expect(closedSpy.callCount).to.equal(1);
+    });
+
+    it('should set error when deleteUser fails', async () => {
+      component.user = mockUser as User;
+      deleteUserService.deleteUser.rejects({ error: { message: 'Server error' } });
+      await stabilize();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await component.submit();
+
+      expect(component.error).to.equal('Server error');
+    });
+
+    it('should set fallback error when API returns no message', async () => {
+      component.user = mockUser as User;
+      deleteUserService.deleteUser.rejects({});
+      await stabilize();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await component.submit();
+
+      expect(component.error).to.equal('Error deleting document');
+    });
+
+    it('should set loading to false after failed delete', async () => {
+      component.user = mockUser as User;
+      deleteUserService.deleteUser.rejects({});
+      await stabilize();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await component.submit();
+
+      expect(component.loading).to.equal(false);
+    });
+  });
+
+  describe('Exceptions', () => {
+    it('should not emit userDeleted when delete fails', async () => {
+      const userDeletedSpy = sinon.spy();
+      component.userDeleted.subscribe(userDeletedSpy);
+      component.user = mockUser as User;
+      deleteUserService.deleteUser.rejects({});
+      await stabilize();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      await component.submit();
+
+      expect(userDeletedSpy.callCount).to.equal(0);
+    });
+  });
+
+  describe('Scenarios', () => {
+    it('should show backdrop when visible', async () => {
+      component.visible = true;
+      component.user = mockUser as User;
+      await stabilize();
+      const backdrop = fixture.nativeElement.querySelector('.modal-backdrop');
+      expect(backdrop).to.exist;
+    });
+
+    it('should disable buttons while loading', async () => {
+      component.visible = true;
+      component.user = mockUser as User;
+      component.loading = true;
+      await stabilize();
+      const buttons = fixture.nativeElement.querySelectorAll('button[disabled]');
+      expect(buttons.length).to.be.greaterThan(0);
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/modules/users/delete-user.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/users/delete-user.component.spec.ts
@@ -90,13 +90,13 @@ describe('DeleteUserComponent', () => {
   describe('Boundaries', () => {
     it('should not call deleteUser when user has no username', async () => {
       component.user = { id: '1' } as User;
-      await component.submit();
+      await component.confirm();
       expect(deleteUserService.deleteUser.callCount).to.equal(0);
     });
 
     it('should not call deleteUser when user is null', async () => {
       component.user = null;
-      await component.submit();
+      await component.confirm();
       expect(deleteUserService.deleteUser.callCount).to.equal(0);
     });
   });
@@ -121,7 +121,7 @@ describe('DeleteUserComponent', () => {
       await stabilize();
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      await component.submit();
+      await component.confirm();
 
       expect(deleteUserService.deleteUser.calledWith('b_wayne')).to.be.true;
     });
@@ -132,7 +132,7 @@ describe('DeleteUserComponent', () => {
       await stabilize();
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      await component.submit();
+      await component.confirm();
 
       expect(usersService.notifyUsersUpdated.callCount).to.equal(1);
     });
@@ -147,7 +147,7 @@ describe('DeleteUserComponent', () => {
       await stabilize();
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      await component.submit();
+      await component.confirm();
 
       expect(userDeletedSpy.callCount).to.equal(1);
       expect(closedSpy.callCount).to.equal(1);
@@ -159,7 +159,7 @@ describe('DeleteUserComponent', () => {
       await stabilize();
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      await component.submit();
+      await component.confirm();
 
       expect(component.error).to.equal('Server error');
     });
@@ -170,7 +170,7 @@ describe('DeleteUserComponent', () => {
       await stabilize();
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      await component.submit();
+      await component.confirm();
 
       expect(component.error).to.equal('Error deleting document');
     });
@@ -181,7 +181,7 @@ describe('DeleteUserComponent', () => {
       await stabilize();
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      await component.submit();
+      await component.confirm();
 
       expect(component.loading).to.equal(false);
     });
@@ -196,7 +196,7 @@ describe('DeleteUserComponent', () => {
       await stabilize();
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      await component.submit();
+      await component.confirm();
 
       expect(userDeletedSpy.callCount).to.equal(0);
     });

--- a/admin-tool/tests/karma/ts/modules/users/edit-user.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/users/edit-user.component.spec.ts
@@ -1,0 +1,413 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { TranslateModule } from '@ngx-translate/core';
+import { EditUserComponent } from '@admin-tool-modules/users/ts/components/edit-user/edit-user.component';
+import { EditUserService } from '@admin-tool-services/edit-user.service';
+import { Select2SearchService } from '@admin-tool-services/select2search.service';
+import { SettingsService } from '@admin-tool-services/settings.service';
+import { UsersService } from '@admin-tool-services/users.service';
+import { User } from '@admin-tool-modules/users/users-interfaces';
+
+describe('EditUserComponent', () => {
+  let component: EditUserComponent;
+  let fixture: ComponentFixture<EditUserComponent>;
+  let editUserService: any;
+  let select2SearchService: any;
+  let settingsService: any;
+  let usersService: any;
+  let httpMock: HttpTestingController;
+  let jqueryInstance: any;
+
+  const mockSettings = (overrides: any = {}) => ({
+    roles: {
+      chw: { name: 'usertype.chw', offline: true },
+      chw_supervisor: { name: 'usertype.chw-supervisor', offline: true },
+      national_admin: { name: 'usertype.national_admin', offline: false },
+    },
+    token_login: { enabled: false },
+    oidc_provider: null,
+    ...overrides,
+  });
+
+  const mockUser: Partial<User> = {
+    id: 'org.couchdb.user:b_wayne',
+    username: 'b_wayne',
+    fullname: 'Bruce Wayne',
+    email: 'bruce@wayne.com',
+    phone: '555-0101',
+    facility_id: 'f1',
+    contact_id: 'c1',
+    roles: ['national_admin'],
+    inactive: false,
+  };
+
+  const stabilize = async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  };
+
+  /**
+   * Sets user, triggers loadSettingsAndPopulate directly (bypassing ngOnChanges/setTimeout),
+   * then stabilizes the zone.
+   */
+  const setupWithUser = async (user: Partial<User>, settingsOverride?: any) => {
+    if (settingsOverride) {
+      settingsService.get.resolves(settingsOverride);
+    }
+    component.user = user as User;
+    component.visible = true;
+    await component.loadSettingsAndPopulate();
+    await stabilize();
+  };
+
+  const flushReplicationLimit = () => {
+    const requests = httpMock.match(r => r.url.includes('/api/v1/users-info'));
+    requests.forEach(req => req.flush({ warn: false }));
+  };
+
+  beforeEach(async () => {
+    jqueryInstance = {
+      val: sinon.stub().returns(null),
+      trigger: sinon.stub().returnsThis(),
+      select2: sinon.stub().returnsThis(),
+      find: sinon.stub().returns({ length: 0 }),
+      append: sinon.stub().returnsThis(),
+    };
+    (window as any).$ = sinon.stub().returns(jqueryInstance);
+
+    editUserService = { updateUser: sinon.stub() };
+    select2SearchService = {
+      initPlaceSelect: sinon.stub().resolves(),
+      initPersonSelect: sinon.stub().resolves(),
+      isContactInPlace: sinon.stub().resolves(true),
+    };
+    settingsService = { get: sinon.stub().resolves(mockSettings()) };
+    usersService = {
+      notifyUsersUpdated: sinon.stub(),
+      usersUpdated$: {
+        subscribe: sinon.stub().callsFake(() => ({ unsubscribe: sinon.stub() })),
+      },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [EditUserComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: EditUserService, useValue: editUserService },
+        { provide: Select2SearchService, useValue: select2SearchService },
+        { provide: SettingsService, useValue: settingsService },
+        { provide: UsersService, useValue: usersService },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EditUserComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sinon.restore();
+  });
+
+  describe('Zero', () => {
+    it('should initialise with visible false', () => {
+      expect(component.visible).to.equal(false);
+    });
+
+    it('should initialise with no errors', () => {
+      expect(Object.keys(component.errors)).to.have.length(0);
+    });
+
+    it('should initialise with loading false', () => {
+      expect(component.loading).to.equal(false);
+    });
+
+    it('should initialise with no available roles before settings load', () => {
+      expect(component.availableRoles).to.have.length(0);
+    });
+
+    it('should load roles from settings when modal becomes visible', async () => {
+      await setupWithUser(mockUser);
+      expect(component.availableRoles.length).to.be.greaterThan(0);
+    });
+
+    it('should exclude _admin role from available roles', async () => {
+      settingsService.get.resolves(mockSettings({
+        roles: { _admin: { name: 'Admin' }, chw: { name: 'CHW', offline: true } },
+      }));
+      await setupWithUser(mockUser);
+      const keys = component.availableRoles.map(r => r.key);
+      expect(keys).to.not.include('_admin');
+    });
+  });
+
+  describe('One', () => {
+    it('should populate model from user when modal becomes visible', async () => {
+      await setupWithUser(mockUser);
+      expect(component.model.username).to.equal('b_wayne');
+      expect(component.model.fullname).to.equal('Bruce Wayne');
+      expect(component.model.email).to.equal('bruce@wayne.com');
+    });
+
+    it('should pre-select user roles', async () => {
+      await setupWithUser(mockUser);
+      expect(component.model.roles).to.include('national_admin');
+    });
+
+    it('should toggle role on and off', async () => {
+      await setupWithUser(mockUser);
+      component.toggleRole('chw');
+      expect(component.model.roles).to.include('chw');
+      component.toggleRole('chw');
+      expect(component.model.roles).to.not.include('chw');
+    });
+
+    it('should toggle password visibility', () => {
+      expect(component.model.showPassword).to.equal(false);
+      component.togglePassword();
+      expect(component.model.showPassword).to.equal(true);
+    });
+  });
+
+  describe('Many', () => {
+    it('should allow multiple roles to be selected', async () => {
+      await setupWithUser(mockUser);
+      component.toggleRole('chw');
+      component.toggleRole('chw_supervisor');
+      expect(component.model.roles).to.include('chw');
+      expect(component.model.roles).to.include('chw_supervisor');
+    });
+  });
+
+  describe('Boundaries', () => {
+    it('should set isOfflineRole when an offline role is selected', async () => {
+      await setupWithUser(mockUser);
+      component.toggleRole('chw');
+      expect(component.isOfflineRole).to.equal(true);
+    });
+
+    it('should set isOfflineRole false when only online roles selected', async () => {
+      await setupWithUser(mockUser);
+      expect(component.isOfflineRole).to.equal(false);
+    });
+
+    it('should hide password when token login is active', async () => {
+      await setupWithUser(
+        { ...mockUser, token_login: { active: true, expiration_date: Date.now() + 10000 } },
+        mockSettings({ token_login: { enabled: true } })
+      );
+      component.model.token_login = true;
+      expect(component.passwordHidden).to.equal(true);
+    });
+
+    it('should hide password when SSO login is active', async () => {
+      settingsService.get.resolves(mockSettings({ oidc_provider: 'https://sso.example.com' }));
+      await setupWithUser(mockUser);
+      component.model.oidc_username = 'bruce@sso.com';
+      expect(component.passwordHidden).to.equal(true);
+    });
+
+    it('should normalise facility_id string to array', async () => {
+      await setupWithUser({ ...mockUser, facility_id: 'f1' });
+      expect(Array.isArray(component.model.place) || component.model.place === null).to.be.true;
+    });
+  });
+
+  describe('Interface', () => {
+    it('should emit closed when cancel is called', () => {
+      const closedSpy = sinon.spy();
+      component.closed.subscribe(closedSpy);
+      component.cancel();
+      expect(closedSpy.callCount).to.equal(1);
+    });
+
+    it('should reset model when cancel is called', async () => {
+      await setupWithUser(mockUser);
+      component.model.fullname = 'Changed Name';
+      component.cancel();
+      expect(component.model.fullname).to.equal('');
+    });
+
+    it('should set roles error when no role is selected on submit', async () => {
+      await setupWithUser(mockUser);
+      component.model.roles = [];
+      await component.submit();
+      expect(component.errors.roles).to.equal('field.required');
+    });
+
+    it('should set email error for invalid email', async () => {
+      await setupWithUser(mockUser);
+      component.model.email = 'not-an-email';
+      await component.submit();
+      expect(component.errors.email).to.equal('email.invalid');
+    });
+
+    it('should set password error when disabling token login without new password', async () => {
+      await setupWithUser(
+        { ...mockUser, token_login: { active: true, expiration_date: Date.now() + 10000 } },
+        mockSettings({ token_login: { enabled: true } })
+      );
+      component.model.token_login = false;
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(component.errors.password).to.equal('field.required');
+    });
+
+    it('should not require password when no change is made', async () => {
+      await setupWithUser(mockUser);
+      editUserService.updateUser.resolves({});
+      component.model.password = '';
+      component.model.passwordConfirm = '';
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(component.errors.password).to.be.undefined;
+    });
+
+    it('should call editUserService.updateUser on valid submit', async () => {
+      await setupWithUser(mockUser);
+      editUserService.updateUser.resolves({});
+      component.model.fullname = 'New Name';
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(editUserService.updateUser.callCount).to.equal(1);
+    });
+
+    it('should notify usersService after successful update', async () => {
+      await setupWithUser(mockUser);
+      editUserService.updateUser.resolves({});
+      component.model.fullname = 'New Name';
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(usersService.notifyUsersUpdated.callCount).to.equal(1);
+    });
+
+    it('should emit userUpdated and closed after successful submit', async () => {
+      const userUpdatedSpy = sinon.spy();
+      const closedSpy = sinon.spy();
+      component.userUpdated.subscribe(userUpdatedSpy);
+      component.closed.subscribe(closedSpy);
+      await setupWithUser(mockUser);
+      editUserService.updateUser.resolves({});
+      component.model.fullname = 'New Name';
+
+      await component.submit();
+
+      expect(userUpdatedSpy.callCount).to.equal(1);
+      expect(closedSpy.callCount).to.equal(1);
+    });
+
+    it('should set submit error when updateUser fails', async () => {
+      await setupWithUser(mockUser);
+      editUserService.updateUser.rejects({ error: { message: 'Update failed' } });
+      component.model.fullname = 'New Name';
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(component.errors.submit).to.equal('Update failed');
+    });
+
+    it('should set fallback error when API returns no message', async () => {
+      await setupWithUser(mockUser);
+      editUserService.updateUser.rejects({});
+      component.model.fullname = 'New Name';
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(component.errors.submit).to.equal('Error updating user');
+    });
+
+    it('should set loading to false after failed submit', async () => {
+      await setupWithUser(mockUser);
+      editUserService.updateUser.rejects({});
+      component.model.fullname = 'New Name';
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(component.loading).to.equal(false);
+    });
+
+    it('should close without calling updateUser when nothing changed', async () => {
+      const closedSpy = sinon.spy();
+      component.closed.subscribe(closedSpy);
+      await setupWithUser(mockUser);
+      // Do not change any field — submit with identical data
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(editUserService.updateUser.callCount).to.equal(0);
+      expect(closedSpy.callCount).to.equal(1);
+    });
+
+    it('should require facility for offline roles', async () => {
+      await setupWithUser({ ...mockUser, roles: [] });
+      component.model.roles = ['chw'];
+      component.model.place = null;
+      component.model.contact = null;
+      const submitPromise = component.submit();
+      flushReplicationLimit();
+      await submitPromise;
+      expect(component.errors.place).to.equal('field.required');
+    });
+
+    it('should set contact error when contact is not in place', async () => {
+      select2SearchService.isContactInPlace.resolves(false);
+      await setupWithUser({ ...mockUser, roles: ['chw'] });
+      component.model.roles = ['chw'];
+      component.model.place = 'f1';
+      component.model.contact = 'c1';
+      await component.submit();
+      expect(component.errors.contact).to.equal('configuration.user.place.contact');
+    });
+  });
+
+  describe('Exceptions', () => {
+    it('should handle settings load failure gracefully', async () => {
+      settingsService.get.rejects(new Error('Settings unavailable'));
+      await setupWithUser(mockUser);
+      expect(component.availableRoles).to.have.length(0);
+    });
+
+    it('should not call updateUser when validation fails', async () => {
+      await setupWithUser(mockUser);
+      component.model.roles = [];
+      await component.submit();
+      expect(editUserService.updateUser.callCount).to.equal(0);
+    });
+  });
+
+  describe('Scenarios', () => {
+    it('should show token login management when token login is already enabled', async () => {
+      await setupWithUser(
+        { ...mockUser, token_login: { active: true, expiration_date: Date.now() + 10000 } },
+        mockSettings({ token_login: { enabled: true } })
+      );
+      expect(component.model.tokenLoginEnabled).to.not.be.null;
+      expect(component.model.tokenLoginEnabled?.active).to.equal(true);
+    });
+
+    it('should show SSO field when oidc_provider is set in settings', async () => {
+      await setupWithUser(mockUser, mockSettings({ oidc_provider: 'https://sso.example.com' }));
+      expect(component.allowSSOLogin).to.equal(true);
+    });
+
+    it('should reset form when visible becomes false', async () => {
+      await setupWithUser(mockUser);
+      expect(component.model.username).to.equal('b_wayne');
+      component.visible = false;
+      component.ngOnChanges({
+        visible: { currentValue: false, previousValue: true, firstChange: false, isFirstChange: () => false },
+      } as any);
+      expect(component.model.username).to.equal('');
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/delete-user.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/delete-user.service.spec.ts
@@ -1,0 +1,129 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DeleteUserService } from '@admin-tool-services/delete-user.service';
+
+describe('DeleteUserService', () => {
+  let service: DeleteUserService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DeleteUserService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(DeleteUserService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sinon.restore();
+  });
+
+  describe('Zero', () => {
+    it('should be created', () => {
+      expect(service).to.exist;
+    });
+  });
+
+  describe('One', () => {
+    it('should call the correct endpoint', async () => {
+      const promise = service.deleteUser('b_wayne');
+      const req = httpMock.expectOne('/api/v1/users/b_wayne');
+      req.flush({});
+      await promise;
+      expect(req.request.method).to.equal('DELETE');
+    });
+
+    it('should include username in the URL', async () => {
+      const promise = service.deleteUser('b_wayne');
+      const req = httpMock.expectOne('/api/v1/users/b_wayne');
+      req.flush({});
+      await promise;
+      expect(req.request.url).to.include('b_wayne');
+    });
+  });
+
+  describe('Boundaries', () => {
+    it('should handle username with hyphens and underscores', async () => {
+      const promise = service.deleteUser('b_wayne-test');
+      const req = httpMock.expectOne('/api/v1/users/b_wayne-test');
+      req.flush({});
+      await promise;
+      expect(req.request.url).to.equal('/api/v1/users/b_wayne-test');
+    });
+  });
+
+  describe('Interface', () => {
+    it('should return a promise', () => {
+      const promise = service.deleteUser('b_wayne');
+      httpMock.expectOne('/api/v1/users/b_wayne').flush({});
+      expect(promise).to.be.instanceOf(Promise);
+    });
+
+    it('should resolve on success', async () => {
+      const promise = service.deleteUser('b_wayne');
+      httpMock.expectOne('/api/v1/users/b_wayne').flush({});
+      await promise; // should not throw
+    });
+
+    it('should send no request body', async () => {
+      const promise = service.deleteUser('b_wayne');
+      const req = httpMock.expectOne('/api/v1/users/b_wayne');
+      req.flush({});
+      await promise;
+      expect(req.request.body).to.be.null;
+    });
+  });
+
+  describe('Exceptions', () => {
+    it('should throw when the request fails', async () => {
+      const promise = service.deleteUser('b_wayne');
+      httpMock.expectOne('/api/v1/users/b_wayne').flush(
+        { error: 'Not found' },
+        { status: 404, statusText: 'Not Found' }
+      );
+
+      try {
+        await promise;
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.status).to.equal(404);
+      }
+    });
+
+    it('should throw on 403 forbidden', async () => {
+      const promise = service.deleteUser('b_wayne');
+      httpMock.expectOne('/api/v1/users/b_wayne').flush(
+        { error: 'Forbidden' },
+        { status: 403, statusText: 'Forbidden' }
+      );
+
+      try {
+        await promise;
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.status).to.equal(403);
+      }
+    });
+  });
+
+  describe('Scenarios', () => {
+    it('should delete different users independently', async () => {
+      const promise1 = service.deleteUser('user1');
+      const promise2 = service.deleteUser('user2');
+
+      httpMock.expectOne('/api/v1/users/user1').flush({});
+      httpMock.expectOne('/api/v1/users/user2').flush({});
+
+      await Promise.all([promise1, promise2]);
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/edit-user.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/edit-user.service.spec.ts
@@ -1,0 +1,130 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { EditUserService } from '@admin-tool-services/edit-user.service';
+
+describe('EditUserService', () => {
+  let service: EditUserService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        EditUserService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(EditUserService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sinon.restore();
+  });
+
+  describe('Zero', () => {
+    it('should be created', () => {
+      expect(service).to.exist;
+    });
+  });
+
+  describe('One', () => {
+    it('should call the correct endpoint', async () => {
+      const promise = service.updateUser('b_wayne', { fullname: 'Bruce Wayne' });
+      const req = httpMock.expectOne('/api/v1/users/b_wayne');
+      req.flush({});
+      await promise;
+      expect(req.request.method).to.equal('POST');
+    });
+
+    it('should send updates in the request body', async () => {
+      const updates = { fullname: 'Bruce Wayne', email: 'bruce@wayne.com' };
+      const promise = service.updateUser('b_wayne', updates);
+      const req = httpMock.expectOne('/api/v1/users/b_wayne');
+      req.flush({});
+      await promise;
+      expect(req.request.body).to.deep.equal(updates);
+    });
+  });
+
+  describe('Boundaries', () => {
+    it('should include username in the URL path', async () => {
+      const promise = service.updateUser('c_kent', { phone: '555-0102' });
+      const req = httpMock.expectOne('/api/v1/users/c_kent');
+      req.flush({});
+      await promise;
+      expect(req.request.url).to.include('c_kent');
+    });
+
+    it('should send empty updates object', async () => {
+      const promise = service.updateUser('b_wayne', {});
+      const req = httpMock.expectOne('/api/v1/users/b_wayne');
+      req.flush({});
+      await promise;
+      expect(req.request.body).to.deep.equal({});
+    });
+  });
+
+  describe('Interface', () => {
+    it('should return a promise', () => {
+      const promise = service.updateUser('b_wayne', {});
+      httpMock.expectOne('/api/v1/users/b_wayne').flush({});
+      expect(promise).to.be.instanceOf(Promise);
+    });
+
+    it('should resolve on success', async () => {
+      const promise = service.updateUser('b_wayne', { fullname: 'Bruce Wayne' });
+      httpMock.expectOne('/api/v1/users/b_wayne').flush({});
+      await promise; // should not throw
+    });
+  });
+
+  describe('Exceptions', () => {
+    it('should throw when the request fails', async () => {
+      const promise = service.updateUser('b_wayne', { fullname: 'Bruce Wayne' });
+      httpMock.expectOne('/api/v1/users/b_wayne').flush(
+        { error: 'Not found' },
+        { status: 404, statusText: 'Not Found' }
+      );
+
+      try {
+        await promise;
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.status).to.equal(404);
+      }
+    });
+
+    it('should throw on 403 forbidden', async () => {
+      const promise = service.updateUser('b_wayne', { roles: ['_admin'] });
+      httpMock.expectOne('/api/v1/users/b_wayne').flush(
+        { error: 'Forbidden' },
+        { status: 403, statusText: 'Forbidden' }
+      );
+
+      try {
+        await promise;
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.status).to.equal(403);
+      }
+    });
+  });
+
+  describe('Scenarios', () => {
+    it('should send only changed fields', async () => {
+      const updates = { email: 'new@wayne.com', phone: '555-9999' };
+      const promise = service.updateUser('b_wayne', updates);
+      const req = httpMock.expectOne('/api/v1/users/b_wayne');
+      req.flush({});
+      await promise;
+      expect(Object.keys(req.request.body)).to.have.length(2);
+      expect(req.request.body.email).to.equal('new@wayne.com');
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/users.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/users.service.spec.ts
@@ -1,13 +1,21 @@
 import { TestBed } from '@angular/core/testing';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinon, { SinonStub } from 'sinon';
 import { UsersService } from '@admin-tool-services/users.service';
 import { DbService } from '@admin-tool-services/db.service';
 
+interface DbInstanceMock {
+  query: SinonStub;
+}
+
+interface DbServiceMock {
+  get: SinonStub;
+}
+
 describe('UsersService', () => {
   let service: UsersService;
-  let dbService: any;
-  let dbInstance: any;
+  let dbService: DbServiceMock;
+  let dbInstance: DbInstanceMock;
 
   beforeEach(() => {
     dbInstance = {

--- a/admin-tool/tests/karma/ts/services/users.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/users.service.spec.ts
@@ -1,19 +1,27 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClient } from '@angular/common/http';
-import { of, throwError } from 'rxjs';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { UsersService } from '@admin-tool-services/users.service';
+import { DbService } from '@admin-tool-services/db.service';
 
 describe('UsersService', () => {
   let service: UsersService;
-  let http: any;
+  let dbService: any;
+  let dbInstance: any;
 
   beforeEach(() => {
-    http = { get: sinon.stub() };
+    dbInstance = {
+      query: sinon.stub(),
+    };
+    dbService = {
+      get: sinon.stub().returns(dbInstance),
+    };
 
     TestBed.configureTestingModule({
-      providers: [UsersService, { provide: HttpClient, useValue: http }],
+      providers: [
+        UsersService,
+        { provide: DbService, useValue: dbService },
+      ],
     });
 
     service = TestBed.inject(UsersService);
@@ -21,47 +29,223 @@ describe('UsersService', () => {
 
   afterEach(() => sinon.restore());
 
-  it('should be created', () => {
-    expect(service).to.exist;
+  describe('Zero', () => {
+    it('should be created', () => {
+      expect(service).to.exist;
+    });
+
+    it('should return empty array when no users exist', async () => {
+      dbInstance.query.resolves({ rows: [] });
+      const result = await service.getUsers();
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should return empty array when rows have no docs', async () => {
+      dbInstance.query.resolves({ rows: [{ doc: null }, { doc: undefined }] });
+      const result = await service.getUsers();
+      expect(result).to.deep.equal([]);
+    });
   });
 
-  it('should call the correct endpoint', async () => {
-    http.get.returns(of([]));
+  describe('One', () => {
+    it('should return one active user', async () => {
+      dbInstance.query.resolves({
+        rows: [{
+          doc: {
+            _id: 'org.couchdb.user:b_wayne',
+            name: 'b_wayne',
+            fullname: 'Bruce Wayne',
+            email: 'bruce@wayne.com',
+            phone: '555-0101',
+            facility_id: 'f1',
+            contact_id: 'c1',
+            roles: ['national_admin'],
+            inactive: false,
+          },
+        }],
+      });
 
-    await service.getUsers();
+      const result = await service.getUsers();
 
-    expect(http.get.calledWith('/api/v2/users')).to.equal(true);
+      expect(result).to.have.length(1);
+      expect(result[0].username).to.equal('b_wayne');
+      expect(result[0].fullname).to.equal('Bruce Wayne');
+      expect(result[0].inactive).to.equal(false);
+    });
+
+    it('should return one inactive user', async () => {
+      dbInstance.query.resolves({
+        rows: [{
+          doc: {
+            _id: 'org.couchdb.user:b_wayne',
+            name: 'b_wayne',
+            fullname: 'Bruce Wayne',
+            inactive: true,
+          },
+        }],
+      });
+
+      const result = await service.getUsers();
+
+      expect(result).to.have.length(1);
+      expect(result[0].inactive).to.equal(true);
+    });
   });
 
-  it('should return list of users', async () => {
-    const mockUsers = [
-      { id: 1, name: 'b_wayne', fullname: 'Bruce Wayne' },
-      { id: 2, name: 't_stark', fullname: 'Tony Stark' },
-    ];
-    http.get.returns(of(mockUsers));
+  describe('Many', () => {
+    it('should return multiple users including inactive ones', async () => {
+      dbInstance.query.resolves({
+        rows: [
+          {
+            doc: {
+              _id: 'org.couchdb.user:b_wayne',
+              name: 'b_wayne',
+              fullname: 'Bruce Wayne',
+              roles: ['national_admin'],
+              inactive: false,
+            },
+          },
+          {
+            doc: {
+              _id: 'org.couchdb.user:c_kent',
+              name: 'c_kent',
+              fullname: 'Clark Kent',
+              roles: ['chw'],
+              inactive: true,
+            },
+          },
+        ],
+      });
 
-    const result = await service.getUsers();
+      const result = await service.getUsers();
 
-    expect(result).to.deep.equal(mockUsers);
+      expect(result).to.have.length(2);
+      expect(result[0].username).to.equal('b_wayne');
+      expect(result[1].username).to.equal('c_kent');
+      expect(result[1].inactive).to.equal(true);
+    });
   });
 
-  it('should return empty array when no users exist', async () => {
-    http.get.returns(of([]));
+  describe('Boundaries', () => {
+    it('should map all user fields correctly', async () => {
+      dbInstance.query.resolves({
+        rows: [{
+          doc: {
+            _id: 'org.couchdb.user:b_wayne',
+            name: 'b_wayne',
+            fullname: 'Bruce Wayne',
+            email: 'bruce@wayne.com',
+            phone: '555-0101',
+            facility_id: ['f1', 'f2'],
+            contact_id: 'c1',
+            roles: ['chw'],
+            inactive: false,
+          },
+        }],
+      });
 
-    const result = await service.getUsers();
+      const result = await service.getUsers();
 
-    expect(result).to.be.an('array');
-    expect(result.length).to.equal(0);
+      expect(result[0]).to.deep.equal({
+        id: 'org.couchdb.user:b_wayne',
+        username: 'b_wayne',
+        fullname: 'Bruce Wayne',
+        email: 'bruce@wayne.com',
+        phone: '555-0101',
+        facility_id: ['f1', 'f2'],
+        contact_id: 'c1',
+        roles: ['chw'],
+        inactive: false,
+      });
+    });
+
+    it('should handle user with no optional fields', async () => {
+      dbInstance.query.resolves({
+        rows: [{
+          doc: {
+            _id: 'org.couchdb.user:b_wayne',
+            name: 'b_wayne',
+          },
+        }],
+      });
+
+      const result = await service.getUsers();
+
+      expect(result[0].username).to.equal('b_wayne');
+      expect(result[0].email).to.be.undefined;
+      expect(result[0].phone).to.be.undefined;
+    });
   });
 
-  it('should throw when the request fails', async () => {
-    http.get.returns(throwError(() => new Error('Network error')));
+  describe('Interface', () => {
+    it('should query the correct CouchDB view', async () => {
+      dbInstance.query.resolves({ rows: [] });
 
-    try {
       await service.getUsers();
-      expect.fail('should have thrown');
-    } catch (err: any) {
-      expect(err.message).to.equal('Network error');
-    }
+
+      expect(dbInstance.query.calledOnce).to.be.true;
+      expect(dbInstance.query.firstCall.args[0]).to.equal('medic-client/doc_by_type');
+      expect(dbInstance.query.firstCall.args[1]).to.deep.equal({
+        include_docs: true,
+        key: ['user-settings'],
+      });
+    });
+
+    it('should call dbService.get to access the database', async () => {
+      dbInstance.query.resolves({ rows: [] });
+
+      await service.getUsers();
+
+      expect(dbService.get.calledOnce).to.be.true;
+    });
+
+    it('should notify subscribers when notifyUsersUpdated is called', () => {
+      const spy = sinon.spy();
+      service.usersUpdated$.subscribe(spy);
+      service.notifyUsersUpdated();
+      expect(spy.callCount).to.equal(2); // once on subscribe, once on notify
+    });
+  });
+
+  describe('Exceptions', () => {
+    it('should throw when the query fails', async () => {
+      dbInstance.query.rejects(new Error('DB error'));
+
+      try {
+        await service.getUsers();
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.message).to.equal('DB error');
+      }
+    });
+  });
+
+  describe('Scenarios', () => {
+    it('should return mix of active and inactive users preserving order', async () => {
+      dbInstance.query.resolves({
+        rows: [
+          { doc: { _id: 'org.couchdb.user:user1', name: 'user1', inactive: false } },
+          { doc: { _id: 'org.couchdb.user:user2', name: 'user2', inactive: true } },
+          { doc: { _id: 'org.couchdb.user:user3', name: 'user3', inactive: false } },
+        ],
+      });
+
+      const result = await service.getUsers();
+
+      expect(result).to.have.length(3);
+      expect(result[0].username).to.equal('user1');
+      expect(result[1].inactive).to.equal(true);
+      expect(result[2].username).to.equal('user3');
+    });
+
+    it('should notify usersUpdated$ multiple times', () => {
+      const spy = sinon.spy();
+      service.usersUpdated$.subscribe(spy);
+
+      service.notifyUsersUpdated();
+      service.notifyUsersUpdated();
+
+      expect(spy.callCount).to.equal(3); // 1 initial + 2 notifications
+    });
   });
 });


### PR DESCRIPTION
# Description

Implements the Edit User and Delete User modals as part of the Users administration module migration from AngularJS to Angular 19.

Closes #5

## What was done

### New components
- `EditUserComponent` — modal form for editing an existing user, pre-populated with current values. Username is read-only. Password is optional (only validated if either password field is filled). Supports Token Login status management (keep/disable/refresh) and SSO username field.
- `DeleteUserComponent` — confirmation modal for deleting a user. Shows the username and warns the action cannot be undone.

### New services
- `EditUserService` — wraps `POST /api/v1/users/:username`
- `DeleteUserService` — wraps `DELETE /api/v1/users/:username`

### Updated files
- `UsersService` — switched from `GET /api/v2/users` to querying the `medic-client/doc_by_type` CouchDB view directly, matching the original AngularJS behaviour. This returns inactive (deleted) users with `inactive: true` so they appear greyed out in the list rather than disappearing after deletion.
- `UsersListComponent` — wired up `<edit-user>` and `<delete-user>` modals with `selectedUser` binding
- `users-interfaces.ts` — added `email`, `token_login`, and `facility_id: string | string[]` to the `User` interface

### Tests
- `edit-user.component.spec.ts`
- `delete-user.component.spec.ts`
- `edit-user.service.spec.ts`
- `delete-user.service.spec.ts`
- `users.service.spec.ts` — updated to mock `DbService` instead of `HttpClient`

## Checklist
- [x] Readable — follows style guide, ESLint passing
- [x] Tested — unit tests added for all new components and services
- [x] Internationalised — all user-facing strings use translation keys matching the legacy AngularJS templates
<img width="1483" height="645" alt="Screenshot 2026-04-16 at 11 26 13 AM" src="https://github.com/user-attachments/assets/076f0bf7-f18e-4297-8dc5-3cb08af6977d" />
<img width="1438" height="568" alt="Screenshot 2026-04-16 at 11 26 30 AM" src="https://github.com/user-attachments/assets/9c7bfed0-a8ec-431b-a690-42b40a3f4bf2" />


