### PR TITLE
feat(#6): implement bulk import users from CSV

### DIFF
--- a/admin-tool/src/ts/modules/users/ts/components/import-users/import-users.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/import-users/import-users.component.html
@@ -1,0 +1,129 @@
+<div>
+  <div
+    class="modal fade"
+    [class.in]="visible"
+    [style.display]="visible ? 'block' : 'none'"
+    role="dialog"
+  >
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <!-- Header -->
+        <div class="modal-header">
+          <button
+            type="button"
+            class="close"
+            (click)="cancel()"
+            aria-label="Close"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title">{{ 'users.import.title' | translate }}</h4>
+        </div>
+
+        <!-- Body -->
+        <div class="modal-body">
+
+          <!-- Error -->
+          @if (error) {
+            <p class="alert alert-danger" role="alert">
+              {{ error | translate }}
+            </p>
+          }
+
+          <!-- Screen 1: Upload -->
+          @if (screen === 'upload') {
+            <div class="text-center">
+              <p>{{ 'users.import.instructions' | translate }}</p>
+              <p><strong>{{ 'users.import.accepted_types' | translate }}</strong></p>
+              <div class="form-actions">
+                <label class="btn btn-primary" for="users-upload-input">
+                  {{ 'users.import.upload_button' | translate }}
+                </label>
+                <input
+                  id="users-upload-input"
+                  type="file"
+                  accept=".csv"
+                  class="hidden"
+                  (change)="onFileSelected($event)"
+                />
+              </div>
+            </div>
+          }
+
+          <!-- Screen 2: Confirm -->
+          @if (screen === 'confirm') {
+            <div class="text-center">
+              <h3>
+                {{ 'users.import.confirm_upload_text' | translate }}
+                <strong>{{ filename }}</strong>?
+              </h3>
+            </div>
+          }
+
+          <!-- Screen 3: Processing -->
+          @if (screen === 'processing') {
+            <div class="text-center">
+              <div class="loader"></div>
+              <h3>{{ 'users.import.processing.title' | translate }}...</h3>
+              <p><small>{{ 'users.import.processing.instructions' | translate }}</small></p>
+            </div>
+          }
+
+          <!-- Screen 4: Summary -->
+          @if (screen === 'summary' && summary) {
+            <div class="row text-center summary-box">
+              <div class="col-sm-4">
+                <p class="text-success summary-number">{{ summary.successful }}</p>
+                <strong>{{ 'users.import.summary.added_users' | translate }}</strong>
+              </div>
+              <div class="col-sm-4">
+                <p class="text-muted summary-number">{{ summary.ignored }}</p>
+                <strong>{{ 'users.import.summary.previously_added_users' | translate }}</strong>
+              </div>
+              <div class="col-sm-4">
+                <p class="text-danger summary-number">{{ summary.failed }}</p>
+                <strong>{{ 'users.import.summary.failed_users' | translate }}</strong>
+              </div>
+            </div>
+            <div class="text-center" style="margin-top: 1rem;">
+              <p>
+                {{ 'users.import.summary.click' | translate }}
+                <a [href]="summary.outputFileUrl" download="cht-imported-users.csv">
+                  {{ 'users.import.summary.here' | translate }}
+                </a>
+                {{ 'users.import.summary.download_status_file' | translate }}
+              </p>
+            </div>
+          }
+
+        </div>
+
+        <!-- Footer -->
+        <div class="modal-footer">
+          @if (screen === 'upload') {
+            <button type="button" class="btn btn-default" (click)="cancel()">
+              {{ 'Cancel' | translate }}
+            </button>
+          }
+          @if (screen === 'confirm') {
+            <button type="button" class="btn btn-default" (click)="backToUpload()">
+              {{ 'users.import.cancel_upload' | translate }}
+            </button>
+            <button type="button" class="btn btn-primary" (click)="processUpload()">
+              {{ 'users.import.confirm_upload' | translate }}
+            </button>
+          }
+          @if (screen === 'summary') {
+            <button type="button" class="btn btn-primary" (click)="finish()">
+              {{ 'users.manage.back' | translate }}
+            </button>
+          }
+        </div>
+      </div>
+    </div>
+  </div>
+
+  @if (visible) {
+    <div class="modal-backdrop fade in"></div>
+  }
+</div>

--- a/admin-tool/src/ts/modules/users/ts/components/import-users/import-users.component.less
+++ b/admin-tool/src/ts/modules/users/ts/components/import-users/import-users.component.less
@@ -1,0 +1,61 @@
+@import 'variables';
+
+.modal {
+  display: block;
+
+  &.in {
+    opacity: 1;
+  }
+
+  .modal-dialog {
+    width: 50%;
+    min-width: 28rem;
+    max-width: 42rem;
+    margin: 10% auto;
+  }
+
+  .modal-header {
+    border-bottom: 0.0625rem solid @gray-light;
+
+    .modal-title {
+      font-size: @font-large;
+      font-weight: bold;
+    }
+
+    .close {
+      font-size: 1.25rem;
+      cursor: pointer;
+    }
+  }
+
+  .modal-body {
+    padding: 1.25rem;
+
+    .hidden {
+      display: none;
+    }
+
+    .summary-box {
+      margin-bottom: 1rem;
+    }
+
+    .summary-number {
+      font-size: 2.5rem;
+      font-weight: bold;
+      margin: 0.5rem 0;
+    }
+  }
+
+  .modal-footer {
+    border-top: 0.0625rem solid @gray-light;
+    text-align: right;
+
+    .btn {
+      margin-left: 0.3125rem;
+    }
+  }
+}
+
+.modal-backdrop {
+  opacity: 0.5;
+}

--- a/admin-tool/src/ts/modules/users/ts/components/import-users/import-users.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/import-users/import-users.component.ts
@@ -1,0 +1,145 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { CreateUserService } from '@admin-tool-services/create-user.service';
+import { UsersService } from '@admin-tool-services/users.service';
+
+type Screen = 'upload' | 'confirm' | 'processing' | 'summary';
+
+export interface ImportSummary {
+  total: number;
+  successful: number;
+  ignored: number;
+  failed: number;
+  outputFileUrl: string;
+}
+
+/**
+ * Modal component for bulk importing users from a CSV file.
+ * Mirrors the AngularJS MultipleUserCtrl flow:
+ *   1. Upload — file picker
+ *   2. Confirm — shows filename, asks to confirm
+ *   3. Processing — spinner while API call runs
+ *   4. Summary — shows counts and download link for status CSV
+ */
+@Component({
+  selector: 'import-users',
+  standalone: true,
+  imports: [TranslatePipe],
+  templateUrl: './import-users.component.html',
+  styleUrl: './import-users.component.less',
+})
+export class ImportUsersComponent {
+  @Input() visible = false;
+  @Output() closed = new EventEmitter<void>();
+
+  screen: Screen = 'upload';
+  filename = '';
+  error: string | null = null;
+  summary: ImportSummary | null = null;
+
+  private uploadedFile: File | null = null;
+
+  constructor(
+    private createUserService: CreateUserService,
+    private usersService: UsersService,
+  ) {}
+
+  onFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+    this.uploadedFile = file;
+    this.filename = file.name;
+    this.screen = 'confirm';
+  }
+
+  async processUpload() {
+    if (!this.uploadedFile) {
+      return;
+    }
+    this.screen = 'processing';
+    this.error = null;
+
+    try {
+      const csv = await this.uploadedFile.text();
+      const results: any[] = await this.createUserService.createMultipleUsers(csv);
+
+      // Build summary from API response array
+      const rows = Array.isArray(results) ? results : [];
+      const successful = rows.filter(r => !r.error).length;
+      const failed = rows.filter(r => !!r.error).length;
+      const outputFileUrl = this.convertResultsToCSV(rows);
+
+      this.summary = {
+        total: rows.length,
+        successful,
+        ignored: 0,
+        failed,
+        outputFileUrl: outputFileUrl ?? '',
+      };
+
+      this.usersService.notifyUsersUpdated();
+      this.screen = 'summary';
+    } catch (err: any) {
+      console.error('Error processing bulk user upload', err);
+      this.error = err?.error?.message || err?.message || 'users.import.error';
+      this.screen = 'upload';
+    }
+  }
+
+  cancel() {
+    this.reset();
+    this.closed.emit();
+  }
+
+  backToUpload() {
+    this.screen = 'upload';
+    this.uploadedFile = null;
+    this.filename = '';
+  }
+
+  finish() {
+    this.reset();
+    this.closed.emit();
+  }
+
+  private reset() {
+    this.screen = 'upload';
+    this.uploadedFile = null;
+    this.filename = '';
+    this.error = null;
+    this.summary = null;
+  }
+
+  private convertResultsToCSV(results: any[]): string {
+    const eol = '\r\n';
+    const delimiter = ',';
+    const columns = ['import.status:excluded', 'import.message:excluded', 'import.username:excluded'];
+    let output = columns.join(delimiter) + eol;
+
+    results.forEach((record: any) => {
+      const status = record.error ? 'error' : 'imported';
+      const message = record.error
+        ? (typeof record.error === 'string' ? record.error : JSON.stringify(record.error))
+        : 'imported on ' + new Date().toISOString();
+      const username = record['user-settings']?.id?.replace('org.couchdb.user:', '') ?? '';
+      output += [
+        this.escapeCSV(status),
+        this.escapeCSV(message),
+        this.escapeCSV(username),
+      ].join(delimiter) + eol;
+    });
+
+    const file = new Blob([output], { type: 'text/csv;charset=utf-8;' });
+    return URL.createObjectURL(file);
+  }
+
+  private escapeCSV(str: string): string {
+    if (!str) {
+      return str;
+    }
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+}

--- a/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.html
@@ -90,5 +90,10 @@
       (closed)="showDeleteModal = false"
       (userDeleted)="showDeleteModal = false"
     ></delete-user>
+
+    <import-users
+      [visible]="showImportModal"
+      (closed)="showImportModal = false"
+    ></import-users>
   }
 </div>

--- a/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.ts
@@ -7,16 +7,17 @@ import { User } from '@admin-tool-modules/users/users-interfaces';
 import { CreateUserComponent } from '../create-user/create-user.component';
 import { EditUserComponent } from '../edit-user/edit-user.component';
 import { DeleteUserComponent } from '../delete-user/delete-user.component';
+import { ImportUsersComponent } from '../import-users/import-users.component';
 
 /**
  * Displays and manages the list of system users.
  * Requires `can_configure` permission to access.
- * Provides hooks for create, edit, and delete actions via modal components.
+ * Provides hooks for create, edit, delete and bulk import actions via modal components.
  */
 @Component({
   selector: 'users-list',
   standalone: true,
-  imports: [TranslatePipe, CreateUserComponent, EditUserComponent, DeleteUserComponent],
+  imports: [TranslatePipe, CreateUserComponent, EditUserComponent, DeleteUserComponent, ImportUsersComponent],
   templateUrl: './users-list.component.html',
   styleUrl: './users-list.component.less',
 })
@@ -29,6 +30,7 @@ export class UsersListComponent implements OnInit, OnDestroy {
   showCreateModal = false;
   showEditModal = false;
   showDeleteModal = false;
+  showImportModal = false;
 
   selectedUser: Partial<User> | null = null;
 
@@ -79,7 +81,7 @@ export class UsersListComponent implements OnInit, OnDestroy {
   }
 
   importUsers() {
-    console.log('import users');
+    this.showImportModal = true;
   }
 
   editUser(user: Partial<User>) {

--- a/admin-tool/src/ts/services/create-user.service.ts
+++ b/admin-tool/src/ts/services/create-user.service.ts
@@ -3,20 +3,19 @@ import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 
 /**
- * Handles HTTP communication with the create user API endpoint.
- * Uses POST /api/v3/users to create a single user.
+ * Handles HTTP communication with the create user API endpoints.
+ * - POST /api/v3/users — creates a single user
+ * - POST /api/v2/users — bulk imports users from a CSV string
  */
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class CreateUserService {
-
   constructor(private http: HttpClient) {}
 
   /**
    * Creates a new user in the system.
    * @param user object containing username, password, roles and optional fields
-   * @returns a promise that resolves when the user is created successfully
    */
   async createUser(user: any): Promise<any> {
     return firstValueFrom(
@@ -24,8 +23,25 @@ export class CreateUserService {
         withCredentials: true,
         headers: {
           'Content-Type': 'application/json',
-          Accept: 'application/json'
-        }
+          Accept: 'application/json',
+        },
+      })
+    );
+  }
+
+  /**
+   * Bulk imports users from a CSV string.
+   * Sends the raw CSV text to POST /api/v2/users.
+   * @param csv raw CSV string
+   */
+  async createMultipleUsers(csv: string): Promise<any> {
+    return firstValueFrom(
+      this.http.post('/api/v2/users', csv, {
+        withCredentials: true,
+        headers: {
+          'Content-Type': 'text/csv',
+          Accept: 'application/json',
+        },
       })
     );
   }

--- a/admin-tool/tests/karma/ts/modules/users/import-users.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/users/import-users.component.spec.ts
@@ -1,0 +1,277 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import sinon, { SinonStub } from 'sinon';
+import { TranslateModule } from '@ngx-translate/core';
+import { ImportUsersComponent } from '@admin-tool-modules/users/ts/components/import-users/import-users.component';
+import { CreateUserService } from '@admin-tool-services/create-user.service';
+import { UsersService } from '@admin-tool-services/users.service';
+
+interface CreateUserServiceMock {
+  createMultipleUsers: SinonStub;
+}
+
+interface UsersServiceMock {
+  notifyUsersUpdated: SinonStub;
+}
+
+describe('ImportUsersComponent', () => {
+  let component: ImportUsersComponent;
+  let fixture: ComponentFixture<ImportUsersComponent>;
+  let createUserService: CreateUserServiceMock;
+  let usersService: UsersServiceMock;
+
+  const mockFile = (content: string, name = 'users.csv'): File => {
+    return new File([content], name, { type: 'text/csv' });
+  };
+
+  const mockFileEvent = (file: File): Event => {
+    const input = { files: [file] } as unknown as HTMLInputElement;
+    return { target: input } as unknown as Event;
+  };
+
+  const stabilize = async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  };
+
+  beforeEach(async () => {
+    createUserService = { createMultipleUsers: sinon.stub() };
+    usersService = { notifyUsersUpdated: sinon.stub() };
+
+    await TestBed.configureTestingModule({
+      imports: [ImportUsersComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: CreateUserService, useValue: createUserService },
+        { provide: UsersService, useValue: usersService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImportUsersComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('Zero', () => {
+    it('should initialise on upload screen', () => {
+      expect(component.screen).to.equal('upload');
+    });
+
+    it('should initialise with no filename', () => {
+      expect(component.filename).to.equal('');
+    });
+
+    it('should initialise with no error', () => {
+      expect(component.error).to.be.null;
+    });
+
+    it('should initialise with no summary', () => {
+      expect(component.summary).to.be.null;
+    });
+
+    it('should initialise with visible false', () => {
+      expect(component.visible).to.equal(false);
+    });
+  });
+
+  describe('One', () => {
+    it('should move to confirm screen when a file is selected', () => {
+      const file = mockFile('username,password\nnight_wing,Str0ng!Pass99');
+      component.onFileSelected(mockFileEvent(file));
+      expect(component.screen).to.equal('confirm');
+    });
+
+    it('should set filename when a file is selected', () => {
+      const file = mockFile('username,password\nnight_wing,Str0ng!Pass99', 'heroes.csv');
+      component.onFileSelected(mockFileEvent(file));
+      expect(component.filename).to.equal('heroes.csv');
+    });
+
+    it('should not change screen when no file is selected', () => {
+      const event = { target: { files: [] } } as unknown as Event;
+      component.onFileSelected(event);
+      expect(component.screen).to.equal('upload');
+    });
+  });
+
+  describe('Many', () => {
+    it('should count successful imports correctly', async () => {
+      createUserService.createMultipleUsers.resolves([
+        { 'user-settings': { id: 'org.couchdb.user:night_wing' } },
+        { 'user-settings': { id: 'org.couchdb.user:star_fire' } },
+        { error: 'Username already taken' },
+      ]);
+
+      component.onFileSelected(mockFileEvent(mockFile('csv content')));
+      await component.processUpload();
+
+      expect(component.summary?.successful).to.equal(2);
+      expect(component.summary?.failed).to.equal(1);
+      expect(component.summary?.total).to.equal(3);
+    });
+
+    it('should count all failures when all rows error', async () => {
+      createUserService.createMultipleUsers.resolves([
+        { error: 'Invalid username' },
+        { error: 'Invalid username' },
+      ]);
+
+      component.onFileSelected(mockFileEvent(mockFile('csv content')));
+      await component.processUpload();
+
+      expect(component.summary?.successful).to.equal(0);
+      expect(component.summary?.failed).to.equal(2);
+    });
+  });
+
+  describe('Boundaries', () => {
+    it('should not call createMultipleUsers when no file is uploaded', async () => {
+      await component.processUpload();
+      expect(createUserService.createMultipleUsers.callCount).to.equal(0);
+    });
+
+    it('should handle empty API response array', async () => {
+      createUserService.createMultipleUsers.resolves([]);
+      component.onFileSelected(mockFileEvent(mockFile('csv content')));
+      await component.processUpload();
+      expect(component.summary?.total).to.equal(0);
+      expect(component.summary?.successful).to.equal(0);
+    });
+
+    it('should handle non-array API response', async () => {
+      createUserService.createMultipleUsers.resolves(null);
+      component.onFileSelected(mockFileEvent(mockFile('csv content')));
+      await component.processUpload();
+      expect(component.summary?.total).to.equal(0);
+    });
+
+    it('should reset filename when backToUpload is called', () => {
+      component.filename = 'heroes.csv';
+      component.screen = 'confirm';
+      component.backToUpload();
+      expect(component.screen).to.equal('upload');
+      expect(component.filename).to.equal('');
+    });
+  });
+
+  describe('Interface', () => {
+    it('should emit closed when cancel is called', () => {
+      const closedSpy = sinon.spy();
+      component.closed.subscribe(closedSpy);
+      component.cancel();
+      expect(closedSpy.callCount).to.equal(1);
+    });
+
+    it('should reset to upload screen when cancel is called', () => {
+      component.screen = 'confirm';
+      component.cancel();
+      expect(component.screen).to.equal('upload');
+    });
+
+    it('should emit closed when finish is called', () => {
+      const closedSpy = sinon.spy();
+      component.closed.subscribe(closedSpy);
+      component.finish();
+      expect(closedSpy.callCount).to.equal(1);
+    });
+
+    it('should reset when finish is called', () => {
+      component.screen = 'summary';
+      component.filename = 'heroes.csv';
+      component.finish();
+      expect(component.screen).to.equal('upload');
+      expect(component.filename).to.equal('');
+    });
+
+    it('should move to processing screen when processUpload is called', async () => {
+      createUserService.createMultipleUsers.resolves([]);
+      component.onFileSelected(mockFileEvent(mockFile('csv')));
+      const promise = component.processUpload();
+      expect(component.screen).to.equal('processing');
+      await promise;
+    });
+
+    it('should move to summary screen after successful upload', async () => {
+      createUserService.createMultipleUsers.resolves([
+        { 'user-settings': { id: 'org.couchdb.user:night_wing' } },
+      ]);
+      component.onFileSelected(mockFileEvent(mockFile('csv')));
+      await component.processUpload();
+      expect(component.screen).to.equal('summary');
+    });
+
+    it('should notify usersService after successful upload', async () => {
+      createUserService.createMultipleUsers.resolves([]);
+      component.onFileSelected(mockFileEvent(mockFile('csv')));
+      await component.processUpload();
+      expect(usersService.notifyUsersUpdated.callCount).to.equal(1);
+    });
+
+    it('should call createMultipleUsers with the file text content', async () => {
+      const csvContent = 'username,password\nnight_wing,Str0ng!Pass99';
+      createUserService.createMultipleUsers.resolves([]);
+      component.onFileSelected(mockFileEvent(mockFile(csvContent)));
+      await component.processUpload();
+      expect(createUserService.createMultipleUsers.calledWith(csvContent)).to.be.true;
+    });
+  });
+
+  describe('Exceptions', () => {
+    it('should show error and return to upload screen when API fails', async () => {
+      createUserService.createMultipleUsers.rejects({ error: { message: 'Server error' } });
+      component.onFileSelected(mockFileEvent(mockFile('csv')));
+      await component.processUpload();
+      expect(component.screen).to.equal('upload');
+      expect(component.error).to.equal('Server error');
+    });
+
+    it('should show fallback error when API returns no message', async () => {
+      createUserService.createMultipleUsers.rejects({});
+      component.onFileSelected(mockFileEvent(mockFile('csv')));
+      await component.processUpload();
+      expect(component.error).to.equal('users.import.error');
+    });
+
+    it('should not notify usersService when upload fails', async () => {
+      createUserService.createMultipleUsers.rejects({});
+      component.onFileSelected(mockFileEvent(mockFile('csv')));
+      await component.processUpload();
+      expect(usersService.notifyUsersUpdated.callCount).to.equal(0);
+    });
+  });
+
+  describe('Scenarios', () => {
+    it('should complete full happy path: select file → confirm → process → summary', async () => {
+      createUserService.createMultipleUsers.resolves([
+        { 'user-settings': { id: 'org.couchdb.user:night_wing' } },
+        { 'user-settings': { id: 'org.couchdb.user:star_fire' } },
+      ]);
+
+      // Step 1: select file
+      component.onFileSelected(mockFileEvent(mockFile('csv', 'heroes.csv')));
+      expect(component.screen).to.equal('confirm');
+      expect(component.filename).to.equal('heroes.csv');
+
+      // Step 2: confirm and process
+      await component.processUpload();
+      expect(component.screen).to.equal('summary');
+      expect(component.summary?.successful).to.equal(2);
+      expect(component.summary?.failed).to.equal(0);
+    });
+
+    it('should show modal when visible is true', async () => {
+      component.visible = true;
+      await stabilize();
+      const modal = fixture.nativeElement.querySelector('.modal.in');
+      expect(modal).to.exist;
+    });
+
+    it('should show upload screen by default', async () => {
+      component.visible = true;
+      await stabilize();
+      const input = fixture.nativeElement.querySelector('input[type="file"]');
+      expect(input).to.exist;
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/create-user.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/create-user.service.spec.ts
@@ -1,0 +1,129 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { CreateUserService } from '@admin-tool-services/create-user.service';
+
+describe('CreateUserService', () => {
+  let service: CreateUserService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        CreateUserService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(CreateUserService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sinon.restore();
+  });
+
+  describe('Zero', () => {
+    it('should be created', () => {
+      expect(service).to.exist;
+    });
+  });
+
+  describe('createUser', () => {
+    it('should POST to /api/v3/users', async () => {
+      const promise = service.createUser({ username: 'night_wing', password: 'Str0ng!Pass99' });
+      const req = httpMock.expectOne('/api/v3/users');
+      req.flush({});
+      await promise;
+      expect(req.request.method).to.equal('POST');
+    });
+
+    it('should send user data in request body', async () => {
+      const user = { username: 'night_wing', password: 'Str0ng!Pass99', roles: ['national_admin'] };
+      const promise = service.createUser(user);
+      const req = httpMock.expectOne('/api/v3/users');
+      req.flush({});
+      await promise;
+      expect(req.request.body).to.deep.equal(user);
+    });
+
+    it('should send Content-Type application/json', async () => {
+      const promise = service.createUser({});
+      const req = httpMock.expectOne('/api/v3/users');
+      req.flush({});
+      await promise;
+      expect(req.request.headers.get('Content-Type')).to.equal('application/json');
+    });
+
+    it('should throw when request fails', async () => {
+      const promise = service.createUser({});
+      httpMock.expectOne('/api/v3/users').flush(
+        { error: 'Bad request' },
+        { status: 400, statusText: 'Bad Request' }
+      );
+      try {
+        await promise;
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.status).to.equal(400);
+      }
+    });
+  });
+
+  describe('createMultipleUsers', () => {
+    it('should POST to /api/v2/users', async () => {
+      const csv = 'username,password\nnight_wing,Str0ng!Pass99';
+      const promise = service.createMultipleUsers(csv);
+      const req = httpMock.expectOne('/api/v2/users');
+      req.flush([]);
+      await promise;
+      expect(req.request.method).to.equal('POST');
+    });
+
+    it('should send CSV string as request body', async () => {
+      const csv = 'username,password\nnight_wing,Str0ng!Pass99';
+      const promise = service.createMultipleUsers(csv);
+      const req = httpMock.expectOne('/api/v2/users');
+      req.flush([]);
+      await promise;
+      expect(req.request.body).to.equal(csv);
+    });
+
+    it('should send Content-Type text/csv', async () => {
+      const promise = service.createMultipleUsers('csv');
+      const req = httpMock.expectOne('/api/v2/users');
+      req.flush([]);
+      await promise;
+      expect(req.request.headers.get('Content-Type')).to.equal('text/csv');
+    });
+
+    it('should return array of results', async () => {
+      const mockResults = [
+        { 'user-settings': { id: 'org.couchdb.user:night_wing' } },
+        { error: 'Username already taken' },
+      ];
+      const promise = service.createMultipleUsers('csv');
+      httpMock.expectOne('/api/v2/users').flush(mockResults);
+      const result = await promise;
+      expect(result).to.deep.equal(mockResults);
+    });
+
+    it('should throw when request fails', async () => {
+      const promise = service.createMultipleUsers('csv');
+      httpMock.expectOne('/api/v2/users').flush(
+        { error: 'Server error' },
+        { status: 500, statusText: 'Internal Server Error' }
+      );
+      try {
+        await promise;
+        expect.fail('should have thrown');
+      } catch (err: any) {
+        expect(err.status).to.equal(500);
+      }
+    });
+  });
+});


### PR DESCRIPTION

# Description

Implements bulk user import from CSV as part of the Users administration module migration from AngularJS to Angular 19.

Closes #6

## What was done

### New component
- `ImportUsersComponent` — multi-screen modal that mirrors the AngularJS `MultipleUserCtrl` flow:
  1. **Upload** — file picker accepting `.csv` files
  2. **Confirm** — shows the filename and asks the user to confirm before processing
  3. **Processing** — spinner while the API call runs
  4. **Summary** — shows successful/failed counts and a download link for the status CSV

### Updated files
- `CreateUserService` — added `createMultipleUsers(csv)` method that posts the raw CSV string to `POST /api/v2/users` with `Content-Type: text/csv`
- `UsersListComponent` — wired up `<import-users>` modal and replaced the `console.log` stub in `importUsers()`

### Notable implementation detail
The original AngularJS version fetched import summary data from a separate logs database (`DB({ logsDB: true })`). The Angular `DbService` only wraps the main `medic` database so this approach is not available. Instead, the summary counts are derived directly from the `POST /api/v2/users` response array, where each row is either a success object or contains an `error` property.

### Tests
- `import-users.component.spec.ts`
- `create-user.service.spec.ts`

## Checklist
- [x] Readable — follows style guide, ESLint passing
- [x] Tested — unit tests added for component and service
- [x] Internationalised — all user-facing strings use `users.import.*` translation keys matching the legacy templates
- [x] AI disclosure — developed with AI assistance per guidelines
<img width="1437" height="711" alt="Screenshot 2026-04-22 at 9 45 07 AM" src="https://github.com/user-attachments/assets/f3e0f4e9-3d60-4753-bdd8-806b30bdae79" />
<img width="1484" height="727" alt="Screenshot 2026-04-22 at 9 47 11 AM" src="https://github.com/user-attachments/assets/608e2b1a-2724-4dd2-b816-e0e737207340" />
