### PR TITLE
feat(#0059): replace in-component permission check with route guard in UsersListComponent

### DIFF
--- a/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.html
@@ -17,7 +17,7 @@
           >
             <span aria-hidden="true">&times;</span>
           </button>
-          <h4 class="modal-title">{{ 'Edit User' | translate }}</h4>
+          <h4 class="modal-title">{{ "Edit User" | translate }}</h4>
         </div>
 
         <!-- Body -->
@@ -36,7 +36,7 @@
 
           <!-- Username — read-only when editing -->
           <div class="form-group">
-            <label for="username">{{ 'User Name' | translate }}</label>
+            <label for="username">{{ "User Name" | translate }}</label>
             <input
               id="username"
               type="text"
@@ -48,19 +48,21 @@
 
           <!-- Full Name -->
           <div class="form-group">
-            <label for="fullname">{{ 'Full Name' | translate }}</label>
+            <label for="fullname">{{ "Full Name" | translate }}</label>
             <input
               id="fullname"
               type="text"
               class="form-control"
               [(ngModel)]="model.fullname"
             />
-            <span class="help-block text-muted">{{ 'user.fullname.help' | translate }}</span>
+            <span class="help-block text-muted">{{
+              "user.fullname.help" | translate
+            }}</span>
           </div>
 
           <!-- Email -->
           <div class="form-group" [class.has-error]="errors.email">
-            <label for="email">{{ 'Email Address' | translate }}</label>
+            <label for="email">{{ "Email Address" | translate }}</label>
             <input
               id="email"
               type="text"
@@ -78,14 +80,16 @@
             [class.required]="model.token_login"
             [class.has-error]="errors.phone"
           >
-            <label for="phone">{{ 'Phone Number' | translate }}</label>
+            <label for="phone">{{ "Phone Number" | translate }}</label>
             <input
               id="phone"
               type="text"
               class="form-control"
               [(ngModel)]="model.phone"
             />
-            <span class="help-block text-muted">{{ 'user.phone.help' | translate }}</span>
+            <span class="help-block text-muted">{{
+              "user.phone.help" | translate
+            }}</span>
             @if (errors.phone) {
               <span class="help-block">{{ errors.phone | translate }}</span>
             }
@@ -93,7 +97,7 @@
 
           <!-- Roles -->
           <div class="form-group required" [class.has-error]="errors.roles">
-            <label>{{ 'configuration.role' | translate }}</label> *
+            <label>{{ "configuration.role" | translate }}</label> *
             <ul class="list-unstyled">
               @for (role of availableRoles; track role.key) {
                 <li class="checkbox">
@@ -120,13 +124,15 @@
             [class.required]="isOfflineRole"
             [class.has-error]="errors.place"
           >
-            <label for="facility-select">{{ 'Facility' | translate }}</label>
+            <label for="facility-select">{{ "Facility" | translate }}</label>
             <select
               id="facility-select"
               class="form-control"
               #facilitySelect
             ></select>
-            <span class="help-block text-muted">{{ 'user.place.help' | translate }}</span>
+            <span class="help-block text-muted">{{
+              "user.place.help" | translate
+            }}</span>
             @if (errors.place) {
               <span class="help-block">{{ errors.place | translate }}</span>
             }
@@ -138,8 +144,12 @@
             [class.required]="isOfflineRole"
             [class.has-error]="errors.contact"
           >
-            <label for="contact-select">{{ 'associated.contact' | translate }}</label>
-            <span class="help-block text-muted">{{ 'associated.contact.help' | translate }}</span>
+            <label for="contact-select">{{
+              "associated.contact" | translate
+            }}</label>
+            <span class="help-block text-muted">{{
+              "associated.contact.help" | translate
+            }}</span>
             <select
               id="contact-select"
               class="form-control"
@@ -151,21 +161,33 @@
           </div>
 
           <!-- SSO Username -->
-          @if (allowSSOLogin && !model.token_login) {
+          @if (
+            allowSSOLogin &&
+            ((model.tokenLoginEnabled && model.token_login === false) ||
+              (!model.tokenLoginEnabled && !model.token_login))
+          ) {
             <div class="form-group">
-              <label for="sso-login">{{ 'user.sso.username' | translate }}</label>
+              <label for="sso-login">{{
+                "user.sso.username" | translate
+              }}</label>
               <input
                 id="sso-login"
                 type="text"
                 class="form-control"
                 [(ngModel)]="model.oidc_username"
               />
-              <span class="help-block text-muted">{{ 'user.sso.username.help' | translate }}</span>
+              <span class="help-block text-muted">{{
+                "user.sso.username.help" | translate
+              }}</span>
             </div>
           }
 
           <!-- Token Login — enable (when not currently enabled) -->
-          @if (allowTokenLogin && !model.tokenLoginEnabled && !(allowSSOLogin && model.oidc_username)) {
+          @if (
+            allowTokenLogin &&
+            !model.tokenLoginEnabled &&
+            !(allowSSOLogin && model.oidc_username)
+          ) {
             <div class="form-group">
               <input
                 type="checkbox"
@@ -173,25 +195,44 @@
                 [(ngModel)]="model.token_login"
               />
               <label for="token-login" class="form-check-label">
-                {{ 'configuration.enable.token.login' | translate }}
+                {{ "configuration.enable.token.login" | translate }}
               </label>
               <div class="help-block text-muted">
-                {{ 'configuration.enable.token.login.help' | translate }}
+                {{ "configuration.enable.token.login.help" | translate }}
               </div>
             </div>
           }
 
           <!-- Token Login — manage (when already enabled) -->
-          @if (allowTokenLogin && model.tokenLoginEnabled && !(allowSSOLogin && model.oidc_username)) {
+          @if (
+            allowTokenLogin &&
+            model.tokenLoginEnabled &&
+            !(allowSSOLogin && model.oidc_username)
+          ) {
             <div class="form-group">
               <p>
                 <label class="form-check-label">
-                  @if (model.tokenLoginEnabled.active && !model.tokenLoginEnabled.expired) {
-                    <span>{{ 'configuration.enable.token.login.enabled.active' | translate }}</span>
-                  } @else if (model.tokenLoginEnabled.active && model.tokenLoginEnabled.expired) {
-                    <span>{{ 'configuration.enable.token.login.enabled.expired' | translate }}</span>
+                  @if (
+                    model.tokenLoginEnabled.active &&
+                    model.tokenLoginEnabled.expiration_date > 0
+                  ) {
+                    <span>{{
+                      "configuration.enable.token.login.enabled.active"
+                        | translate
+                    }}</span>
+                  } @else if (
+                    model.tokenLoginEnabled.active &&
+                    !model.tokenLoginEnabled.expiration_date
+                  ) {
+                    <span>{{
+                      "configuration.enable.token.login.enabled.expired"
+                        | translate
+                    }}</span>
                   } @else {
-                    <span>{{ 'configuration.enable.token.login.enabled.inactive' | translate }}</span>
+                    <span>{{
+                      "configuration.enable.token.login.enabled.inactive"
+                        | translate
+                    }}</span>
                   }
                 </label>
               </p>
@@ -203,7 +244,7 @@
                   [(ngModel)]="model.token_login"
                 />
                 <label for="unmodified-token-login" class="form-check-label">
-                  {{ 'configuration.enable.token.login.no.modify' | translate }}
+                  {{ "configuration.enable.token.login.no.modify" | translate }}
                 </label>
               </div>
               <div>
@@ -214,7 +255,7 @@
                   [(ngModel)]="model.token_login"
                 />
                 <label for="disable-token-login" class="form-check-label">
-                  {{ 'configuration.enable.token.login.disable' | translate }}
+                  {{ "configuration.enable.token.login.disable" | translate }}
                 </label>
               </div>
               <div>
@@ -225,11 +266,13 @@
                   [(ngModel)]="model.token_login"
                 />
                 <label for="refresh-token-login" class="form-check-label">
-                  {{ 'configuration.enable.token.login.refresh' | translate }}
+                  {{ "configuration.enable.token.login.refresh" | translate }}
                 </label>
               </div>
               <div class="help-block text-muted">
-                {{ 'configuration.enable.token.login.refresh.help' | translate }}
+                {{
+                  "configuration.enable.token.login.refresh.help" | translate
+                }}
               </div>
             </div>
           }
@@ -237,7 +280,7 @@
           <!-- Password — optional for existing users, hidden when token/SSO active -->
           @if (!passwordHidden) {
             <div class="form-group" [class.has-error]="errors.password">
-              <label for="password">{{ 'Password' | translate }}</label>
+              <label for="password">{{ "Password" | translate }}</label>
               <div class="input-group">
                 <input
                   id="password"
@@ -251,7 +294,10 @@
                     type="button"
                     class="btn btn-default"
                     (click)="togglePassword()"
-                    [attr.aria-label]="(model.showPassword ? 'password.hide' : 'password.show') | translate"
+                    [attr.aria-label]="
+                      (model.showPassword ? 'password.hide' : 'password.show')
+                        | translate
+                    "
                   >
                     <i
                       class="fa fa-eye"
@@ -261,13 +307,17 @@
                 </span>
               </div>
               @if (errors.password) {
-                <span class="help-block">{{ errors.password | translate }}</span>
+                <span class="help-block">{{
+                  errors.password | translate
+                }}</span>
               }
             </div>
 
             <!-- Confirm Password -->
             <div class="form-group" [class.has-error]="errors.passwordConfirm">
-              <label for="password-confirm">{{ 'Confirm Password' | translate }}</label>
+              <label for="password-confirm">{{
+                "Confirm Password" | translate
+              }}</label>
               <input
                 id="password-confirm"
                 [type]="model.showPassword ? 'text' : 'password'"
@@ -276,7 +326,9 @@
                 autocomplete="new-password"
               />
               @if (errors.passwordConfirm) {
-                <span class="help-block">{{ errors.passwordConfirm | translate }}</span>
+                <span class="help-block">{{
+                  errors.passwordConfirm | translate
+                }}</span>
               }
             </div>
           }
@@ -290,7 +342,7 @@
             (click)="cancel()"
             [disabled]="loading"
           >
-            {{ 'Cancel' | translate }}
+            {{ "Cancel" | translate }}
           </button>
           <button
             type="button"
@@ -300,9 +352,9 @@
           >
             @if (loading) {
               <i class="fa fa-spinner fa-spin"></i>
-              {{ 'Submitting' | translate }}
+              {{ "Submitting" | translate }}
             } @else {
-              {{ 'Submit' | translate }}
+              {{ "Submit" | translate }}
             }
           </button>
         </div>

--- a/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/edit-user/edit-user.component.ts
@@ -1,7 +1,12 @@
 import {
-  Component, Input, Output, EventEmitter,
-  OnChanges, SimpleChanges,
-  ViewChild, ElementRef
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnChanges,
+  SimpleChanges,
+  ViewChild,
+  ElementRef,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
@@ -48,12 +53,8 @@ export interface EditUserModel {
   place: string | string[] | null;
   contact: string | null;
   token_login: boolean | '' | null;
-  tokenLoginEnabled: {
-    active: boolean;
-    expired: boolean;
-    expirationDate: string;
-    loginDate?: string;
-  } | null;
+  /** Raw token_login data as returned by the server — not transformed client-side. */
+  tokenLoginEnabled: User['token_login'] | null;
   oidc_username: string;
   password: string;
   passwordConfirm: string;
@@ -95,7 +96,9 @@ export class EditUserComponent implements OnChanges {
   @Output() closed = new EventEmitter<void>();
   @Output() userUpdated = new EventEmitter<void>();
 
-  @ViewChild('facilitySelect') facilitySelectRef!: ElementRef<HTMLSelectElement>;
+  @ViewChild('facilitySelect')
+  facilitySelectRef!: ElementRef<HTMLSelectElement>;
+
   @ViewChild('contactSelect') contactSelectRef!: ElementRef<HTMLSelectElement>;
 
   loading = false;
@@ -107,7 +110,9 @@ export class EditUserComponent implements OnChanges {
 
   model: EditUserModel = getInitialModel();
 
-  private settingsRoles: Record<string, { name: string; offline?: boolean }> = {};
+  private settingsRoles: Record<string, { name: string; offline?: boolean }> =
+    {};
+
   private cachedSettings: any = null;
   private originalModel: EditUserModel = getInitialModel();
 
@@ -160,32 +165,19 @@ export class EditUserComponent implements OnChanges {
         : [this.user.facility_id]
       : null;
 
-    const tokenLoginData = (this.user as any).token_login;
-    const tokenLoginEnabled = tokenLoginData
-      ? {
-        active: tokenLoginData.active,
-        expired: tokenLoginData.expiration_date <= new Date().getTime(),
-        expirationDate: tokenLoginData.expiration_date
-          ? new Date(tokenLoginData.expiration_date).toLocaleDateString()
-          : '',
-        loginDate: tokenLoginData.login_date
-          ? new Date(tokenLoginData.login_date).toLocaleDateString()
-          : undefined,
-      }
-      : null;
-
     this.model = {
       id: this.user.id || '',
       username: this.user.username || '',
       fullname: this.user.fullname || '',
-      email: (this.user as any).email || '',
+      email: this.user.email || '',
       phone: this.user.phone || '',
       roles: this.filterRoles(this.user.roles || []),
       place: facilityId,
       contact: this.user.contact_id || null,
       token_login: null,
-      tokenLoginEnabled,
-      oidc_username: (this.user as any).oidc_username || '',
+      // Pass through server data as-is — do not compute derived fields client-side
+      tokenLoginEnabled: this.user.token_login ?? null,
+      oidc_username: this.user.oidc_username || '',
       password: '',
       passwordConfirm: '',
       showPassword: false,
@@ -203,7 +195,7 @@ export class EditUserComponent implements OnChanges {
     if (roles.includes('_admin')) {
       return ['_admin'];
     }
-    return roles.filter(role => !!this.settingsRoles[role]);
+    return roles.filter((role) => !!this.settingsRoles[role]);
   }
 
   private async initSelect2() {
@@ -211,18 +203,20 @@ export class EditUserComponent implements OnChanges {
       // initialValue accepts a single string — preselect the first place if multiple
       const placeIds = Array.isArray(this.model.place)
         ? this.model.place
-        : this.model.place ? [this.model.place] : [];
+        : this.model.place
+          ? [this.model.place]
+          : [];
       const initialValue = placeIds[0] || undefined;
       await this.select2SearchService.initPlaceSelect(
         this.facilitySelectRef.nativeElement,
-        { initialValue }
+        { initialValue },
       );
     }
     if (this.contactSelectRef?.nativeElement) {
       const initialValue = this.model.contact || undefined;
       await this.select2SearchService.initPersonSelect(
         this.contactSelectRef.nativeElement,
-        { initialValue }
+        { initialValue },
       );
     }
   }
@@ -231,7 +225,8 @@ export class EditUserComponent implements OnChanges {
     if (this.facilitySelectRef?.nativeElement) {
       const val = $(this.facilitySelectRef.nativeElement).val();
       if (typeof val === 'string' || Array.isArray(val)) {
-        this.model.place = Array.isArray(val) && val.length === 0 ? null : val as string;
+        this.model.place =
+          Array.isArray(val) && val.length === 0 ? null : (val as string);
       }
     }
     if (this.contactSelectRef?.nativeElement) {
@@ -243,14 +238,19 @@ export class EditUserComponent implements OnChanges {
   }
 
   private isOfflineUser(): boolean {
-    return this.model.roles.some(role => this.settingsRoles[role]?.offline === true);
+    return this.model.roles.some(
+      (role) => this.settingsRoles[role]?.offline === true,
+    );
   }
 
   get passwordHidden(): boolean {
-    return (this.allowTokenLogin && (
-      !!this.model.token_login ||
-      (this.model.token_login !== false && !!this.model.tokenLoginEnabled)
-    )) || (this.allowSSOLogin && !!this.model.oidc_username);
+    return (
+      (this.allowTokenLogin &&
+        (!!this.model.token_login ||
+          (this.model.token_login !== false &&
+            !!this.model.tokenLoginEnabled))) ||
+      (this.allowSSOLogin && !!this.model.oidc_username)
+    );
   }
 
   cancel() {
@@ -327,7 +327,6 @@ export class EditUserComponent implements OnChanges {
     const eitherFieldFilled = this.model.password || this.model.passwordConfirm;
 
     if (!disablingTokenLogin && !eitherFieldFilled) {
-      // Existing user, no password change — skip validation
       return;
     }
 
@@ -366,8 +365,13 @@ export class EditUserComponent implements OnChanges {
       return true;
     }
 
-    const placeIds = Array.isArray(this.model.place) ? this.model.place : [this.model.place];
-    const valid = await this.select2SearchService.isContactInPlace(this.model.contact, placeIds);
+    const placeIds = Array.isArray(this.model.place)
+      ? this.model.place
+      : [this.model.place];
+    const valid = await this.select2SearchService.isContactInPlace(
+      this.model.contact,
+      placeIds,
+    );
 
     if (!valid) {
       this.errors.contact = 'configuration.user.place.contact';
@@ -388,10 +392,11 @@ export class EditUserComponent implements OnChanges {
         contact_id: this.model.contact,
       };
       const resp: any = await firstValueFrom(
-        this.http.get('/api/v1/users-info', { params })
+        this.http.get('/api/v1/users-info', { params }),
       );
       if (resp?.warn) {
-        this.errors.replicationLimit = 'configuration.user.replication.limit.exceeded';
+        this.errors.replicationLimit =
+          'configuration.user.replication.limit.exceeded';
         return false;
       }
     } catch (err) {
@@ -479,7 +484,6 @@ export class EditUserComponent implements OnChanges {
 
     const updates = this.getChangedUpdates();
     if (!Object.keys(updates).length) {
-      // Nothing changed — just close
       this.reset();
       this.closed.emit();
       return;

--- a/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.html
+++ b/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.html
@@ -1,99 +1,97 @@
 <div>
-  @if (canConfigure) {
-    <legend>{{ 'Users' | translate }}</legend>
-    <div class="btn-toolbar">
-      <button id="add-user" class="btn btn-primary" (click)="addUser()">
-        <span>{{ 'users.manage.add_single_user' | translate }}</span>
-      </button>
-      <button id="add-users" class="btn btn-primary" (click)="importUsers()">
-        <span>{{ 'users.manage.import_users' | translate }}</span>
-      </button>
-    </div>
+  <legend>{{ "Users" | translate }}</legend>
+  <div class="btn-toolbar">
+    <button id="add-user" class="btn btn-primary" (click)="addUser()">
+      <span>{{ "users.manage.add_single_user" | translate }}</span>
+    </button>
+    <button id="add-users" class="btn btn-primary" (click)="importUsers()">
+      <span>{{ "users.manage.import_users" | translate }}</span>
+    </button>
+  </div>
 
-    @if (loading) {
-      <div class="loader"></div>
+  @if (loading) {
+    <div class="loader"></div>
+  } @else {
+    @if (error) {
+      <p class="alert alert-danger" role="alert">
+        {{ "Error fetching users" | translate }}
+      </p>
     } @else {
-      @if (error) {
-        <p class="alert alert-danger" role="alert">
-          {{ 'Error fetching users' | translate }}
-        </p>
-      } @else {
-        <div class="container-fluid">
-          <div class="row selection-heading">
-            <div class="col-xs-3">{{ 'User Name' | translate }}</div>
-            <div class="col-xs-3">{{ 'Full Name' | translate }}</div>
-            <div class="col-xs-3">{{ 'Phone Number' | translate }}</div>
-            <div class="col-xs-1">{{ 'Facility' | translate }}</div>
-            <div class="col-xs-1">{{ 'Contact' | translate }}</div>
-            <div class="col-xs-1"></div>
-          </div>
-
-          @if (users.length === 0) {
-            <div class="text-center empty-state">
-              <p>{{ 'users.list.empty' | translate }}</p>
-            </div>
-          } @else {
-            @for (user of users; track user.id) {
-              <div
-                class="row selection"
-                (click)="onRowClick(user)"
-                [class.inactive]="user.inactive"
-                [title]="user.inactive ? ('Deleted user' | translate) : ''"
-              >
-                <div class="col-xs-3">{{ user.username }}</div>
-                <div class="col-xs-3">{{ user.fullname }}</div>
-                <div class="col-xs-3">{{ user.phone }}</div>
-                <div class="col-xs-1">
-                  @if (user.facility_id) {
-                    <i class="fa fa-check"></i>
-                  }
-                </div>
-                <div class="col-xs-1">
-                  @if (user.contact_id) {
-                    <i class="fa fa-check"></i>
-                  }
-                </div>
-                <div class="col-xs-1 delete">
-                  @if (!user.inactive) {
-                    <button
-                      class="btn btn-sm btn-danger"
-                      (click)="deleteUser(user, $event)"
-                      [attr.aria-label]="'Delete user' | translate"
-                    >
-                      <i class="fa fa-trash-o"></i>
-                    </button>
-                  }
-                </div>
-              </div>
-            }
-          }
+      <div class="container-fluid">
+        <div class="row selection-heading">
+          <div class="col-xs-3">{{ "User Name" | translate }}</div>
+          <div class="col-xs-3">{{ "Full Name" | translate }}</div>
+          <div class="col-xs-3">{{ "Phone Number" | translate }}</div>
+          <div class="col-xs-1">{{ "Facility" | translate }}</div>
+          <div class="col-xs-1">{{ "Contact" | translate }}</div>
+          <div class="col-xs-1"></div>
         </div>
-      }
+
+        @if (users.length === 0) {
+          <div class="text-center empty-state">
+            <p>{{ "users.list.empty" | translate }}</p>
+          </div>
+        } @else {
+          @for (user of users; track user.id) {
+            <div
+              class="row selection"
+              (click)="onRowClick(user)"
+              [class.inactive]="user.inactive"
+              [title]="user.inactive ? ('Deleted user' | translate) : ''"
+            >
+              <div class="col-xs-3">{{ user.username }}</div>
+              <div class="col-xs-3">{{ user.fullname }}</div>
+              <div class="col-xs-3">{{ user.phone }}</div>
+              <div class="col-xs-1">
+                @if (user.facility_id) {
+                  <i class="fa fa-check"></i>
+                }
+              </div>
+              <div class="col-xs-1">
+                @if (user.contact_id) {
+                  <i class="fa fa-check"></i>
+                }
+              </div>
+              <div class="col-xs-1 delete">
+                @if (!user.inactive) {
+                  <button
+                    class="btn btn-sm btn-danger"
+                    (click)="deleteUser(user, $event)"
+                    [attr.aria-label]="'Delete user' | translate"
+                  >
+                    <i class="fa fa-trash-o"></i>
+                  </button>
+                }
+              </div>
+            </div>
+          }
+        }
+      </div>
     }
-
-    <create-user
-      [visible]="showCreateModal"
-      (closed)="showCreateModal = false"
-      (userCreated)="showCreateModal = false"
-    ></create-user>
-
-    <edit-user
-      [visible]="showEditModal"
-      [user]="selectedUser"
-      (closed)="showEditModal = false"
-      (userUpdated)="showEditModal = false"
-    ></edit-user>
-
-    <delete-user
-      [visible]="showDeleteModal"
-      [user]="selectedUser"
-      (closed)="showDeleteModal = false"
-      (userDeleted)="showDeleteModal = false"
-    ></delete-user>
-
-    <import-users
-      [visible]="showImportModal"
-      (closed)="showImportModal = false"
-    ></import-users>
   }
+
+  <create-user
+    [visible]="showCreateModal"
+    (closed)="showCreateModal = false"
+    (userCreated)="showCreateModal = false"
+  ></create-user>
+
+  <edit-user
+    [visible]="showEditModal"
+    [user]="selectedUser"
+    (closed)="showEditModal = false"
+    (userUpdated)="showEditModal = false"
+  ></edit-user>
+
+  <delete-user
+    [visible]="showDeleteModal"
+    [user]="selectedUser"
+    (closed)="showDeleteModal = false"
+    (userDeleted)="showDeleteModal = false"
+  ></delete-user>
+
+  <import-users
+    [visible]="showImportModal"
+    (closed)="showImportModal = false"
+  ></import-users>
 </div>

--- a/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.ts
+++ b/admin-tool/src/ts/modules/users/ts/components/users-list/users-list.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { TranslatePipe } from '@ngx-translate/core';
-import { AuthService } from '@admin-tool-services/auth.service';
 import { UsersService } from '@admin-tool-services/users.service';
 import { User } from '@admin-tool-modules/users/users-interfaces';
 import { CreateUserComponent } from '../create-user/create-user.component';
@@ -11,18 +10,23 @@ import { ImportUsersComponent } from '../import-users/import-users.component';
 
 /**
  * Displays and manages the list of system users.
- * Requires `can_configure` permission to access.
+ * Access is controlled by the route guard (can_configure permission).
  * Provides hooks for create, edit, delete and bulk import actions via modal components.
  */
 @Component({
   selector: 'users-list',
   standalone: true,
-  imports: [TranslatePipe, CreateUserComponent, EditUserComponent, DeleteUserComponent, ImportUsersComponent],
+  imports: [
+    TranslatePipe,
+    CreateUserComponent,
+    EditUserComponent,
+    DeleteUserComponent,
+    ImportUsersComponent,
+  ],
   templateUrl: './users-list.component.html',
   styleUrl: './users-list.component.less',
 })
 export class UsersListComponent implements OnInit, OnDestroy {
-  canConfigure = false;
   loading = false;
   error = false;
   users: Partial<User>[] = [];
@@ -36,21 +40,12 @@ export class UsersListComponent implements OnInit, OnDestroy {
 
   private usersUpdatedSubscription!: Subscription;
 
-  constructor(
-    private authService: AuthService,
-    private usersService: UsersService,
-  ) {}
+  constructor(private usersService: UsersService) {}
 
-  ngOnInit() {
-    this.authService.has('can_configure').then((result) => {
-      this.canConfigure = result;
-      if (result) {
-        this.loadUsers();
-      }
-    });
-
+  async ngOnInit() {
+    await this.loadUsers();
     this.usersUpdatedSubscription = this.usersService.usersUpdated$.subscribe(
-      () => this.loadUsers()
+      () => this.loadUsers(),
     );
   }
 

--- a/admin-tool/src/ts/modules/users/users-interfaces.ts
+++ b/admin-tool/src/ts/modules/users/users-interfaces.ts
@@ -11,6 +11,7 @@ export interface User {
   contact_id?: string;
   inactive?: boolean;
   roles?: string[];
+  oidc_username?: string;
   token_login?: {
     active: boolean;
     expiration_date: number;

--- a/admin-tool/src/ts/modules/users/users.routes.ts
+++ b/admin-tool/src/ts/modules/users/users.routes.ts
@@ -1,9 +1,12 @@
 import { Routes } from '@angular/router';
 import { UsersComponent } from './users.component';
+import { AppRouteGuardProvider } from '@admin-tool-providers/app-route.guard.provider';
 
 export const routes: Routes = [
   {
     path: 'users',
     component: UsersComponent,
+    canActivate: [AppRouteGuardProvider],
+    data: { permissions: 'can_configure' },
   },
 ];

--- a/admin-tool/tests/karma/ts/modules/users/users-list.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/users/users-list.component.spec.ts
@@ -5,7 +5,6 @@ import { TranslateModule } from '@ngx-translate/core';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { UsersListComponent } from '@admin-tool-modules/users/ts/components/users-list/users-list.component';
-import { AuthService } from '@admin-tool-services/auth.service';
 import { UsersService } from '@admin-tool-services/users.service';
 import { SettingsService } from '@admin-tool-services/settings.service';
 import { ChangesService } from '@admin-tool-services/changes.service';
@@ -24,26 +23,33 @@ const mockUser = (overrides = {}) => ({
 describe('UsersListComponent', () => {
   let fixture: ComponentFixture<UsersListComponent>;
   let component: UsersListComponent;
-  let authService: any;
   let usersService: any;
 
   beforeEach(async () => {
-    authService = { has: sinon.stub() };
     const unsubscribeStub = sinon.stub();
     usersService = {
       getUsers: sinon.stub(),
       usersUpdated$: {
-        subscribe: sinon.stub().callsFake((_cb: any) => ({ unsubscribe: unsubscribeStub })),
+        subscribe: sinon
+          .stub()
+          .callsFake((_cb: any) => ({ unsubscribe: unsubscribeStub })),
       },
     };
 
     await TestBed.configureTestingModule({
       imports: [UsersListComponent, TranslateModule.forRoot()],
       providers: [
-        { provide: AuthService, useValue: authService },
         { provide: UsersService, useValue: usersService },
-        { provide: SettingsService, useValue: { get: sinon.stub().resolves({}) } },
-        { provide: ChangesService, useValue: { subscribe: sinon.stub().returns({ unsubscribe: sinon.stub() }) } },
+        {
+          provide: SettingsService,
+          useValue: { get: sinon.stub().resolves({}) },
+        },
+        {
+          provide: ChangesService,
+          useValue: {
+            subscribe: sinon.stub().returns({ unsubscribe: sinon.stub() }),
+          },
+        },
         provideHttpClient(),
         provideHttpClientTesting(),
       ],
@@ -55,35 +61,25 @@ describe('UsersListComponent', () => {
 
   afterEach(() => sinon.restore());
 
-  // --- ZERO ---
   describe('Zero', () => {
     it('should show empty list when no users are returned', async () => {
-      authService.has.resolves(true);
       usersService.getUsers.resolves([]);
-
       fixture.detectChanges();
       await fixture.whenStable();
-
       expect(component.users.length).to.equal(0);
     });
 
     it('should not show loader after empty list loads', async () => {
-      authService.has.resolves(true);
       usersService.getUsers.resolves([]);
-
       fixture.detectChanges();
       await fixture.whenStable();
-
       expect(component.loading).to.equal(false);
     });
   });
 
-  // --- ONE ---
   describe('One', () => {
     it('should show one user in the list', async () => {
-      authService.has.resolves(true);
       usersService.getUsers.resolves([mockUser()]);
-
       fixture.detectChanges();
       await fixture.whenStable();
       expect(component.users.length).to.equal(1);
@@ -91,35 +87,27 @@ describe('UsersListComponent', () => {
     });
   });
 
-  // --- MANY ---
   describe('Many', () => {
     it('should show multiple users in the list', async () => {
-      authService.has.resolves(true);
       usersService.getUsers.resolves([
-        mockUser({ id: 1, name: 'b_wayne' }),
-        mockUser({ id: 2, name: 't_stark' }),
-        mockUser({ id: 3, name: 'p_parker' }),
+        mockUser({ id: '1', username: 'b_wayne' }),
+        mockUser({ id: '2', username: 't_stark' }),
+        mockUser({ id: '3', username: 'p_parker' }),
       ]);
-
       fixture.detectChanges();
       await fixture.whenStable();
-
       expect(component.users.length).to.equal(3);
     });
   });
 
-  // --- BOUNDARIES ---
   describe('Boundaries', () => {
     it('should mark inactive users correctly', async () => {
-      authService.has.resolves(true);
       usersService.getUsers.resolves([
-        mockUser({ id: 1, inactive: false }),
-        mockUser({ id: 2, inactive: true }),
+        mockUser({ id: '1', inactive: false }),
+        mockUser({ id: '2', inactive: true }),
       ]);
-
       fixture.detectChanges();
       await fixture.whenStable();
-
       expect(component.users[0].inactive).to.equal(false);
       expect(component.users[1].inactive).to.equal(true);
     });
@@ -127,54 +115,28 @@ describe('UsersListComponent', () => {
     it('should not call editUser when clicking an inactive user', () => {
       const editStub = sinon.stub(component, 'editUser');
       const inactiveUser = mockUser({ inactive: true });
-
       if (!inactiveUser.inactive) {
         component.editUser(inactiveUser);
       }
-
       expect(editStub.callCount).to.equal(0);
     });
 
     it('should call editUser when clicking an active user', () => {
       const editStub = sinon.stub(component, 'editUser');
       const activeUser = mockUser({ inactive: false });
-
       if (!activeUser.inactive) {
         component.editUser(activeUser);
       }
-
       expect(editStub.callCount).to.equal(1);
     });
   });
 
-  // --- INTERFACE ---
   describe('Interface', () => {
-    it('should call authService.has with can_configure on init', async () => {
-      authService.has.resolves(false);
-
-      fixture.detectChanges();
-      await fixture.whenStable();
-
-      expect(authService.has.calledWith('can_configure')).to.equal(true);
-    });
-
-    it('should call usersService.getUsers when user has permission', async () => {
-      authService.has.resolves(true);
+    it('should call usersService.getUsers on init', async () => {
       usersService.getUsers.resolves([]);
-
       fixture.detectChanges();
       await fixture.whenStable();
-
       expect(usersService.getUsers.callCount).to.equal(1);
-    });
-
-    it('should not call usersService.getUsers when user lacks permission', async () => {
-      authService.has.resolves(false);
-
-      fixture.detectChanges();
-      await fixture.whenStable();
-
-      expect(usersService.getUsers.callCount).to.equal(0);
     });
 
     it('deleteUser should stop event propagation', () => {
@@ -208,72 +170,43 @@ describe('UsersListComponent', () => {
     });
   });
 
-  // --- EXCEPTIONS ---
   describe('Exceptions', () => {
     it('should set error to true when getUsers fails', async () => {
-      authService.has.resolves(true);
       usersService.getUsers.rejects(new Error('API error'));
-
       fixture.detectChanges();
       await fixture.whenStable();
-
       expect(component.error).to.equal(true);
     });
 
     it('should set loading to false even when getUsers fails', async () => {
-      authService.has.resolves(true);
       usersService.getUsers.rejects(new Error('API error'));
-
       fixture.detectChanges();
       await fixture.whenStable();
-
       expect(component.loading).to.equal(false);
-    });
-
-    it('should not show users when user lacks can_configure permission', async () => {
-      authService.has.resolves(false);
-
-      fixture.detectChanges();
-      await fixture.whenStable();
-
-      expect(component.canConfigure).to.equal(false);
-      expect(component.users.length).to.equal(0);
     });
   });
 
-  // --- SCENARIOS ---
   describe('Scenarios', () => {
-    it('should complete full flow: permission check → load → display users', async () => {
-      const users = [
-        mockUser({ id: 1, name: 'b_wayne' }),
-        mockUser({ id: 2, name: 't_stark' }),
-      ];
-
-      authService.has.resolves(true);
-      usersService.getUsers.resolves(users);
-
+    it('should load and display users on init', async () => {
+      usersService.getUsers.resolves([
+        mockUser({ id: '1', username: 'b_wayne' }),
+        mockUser({ id: '2', username: 't_stark' }),
+      ]);
       fixture.detectChanges();
       await fixture.whenStable();
-
-      expect(component.canConfigure).to.equal(true);
       expect(component.loading).to.equal(false);
       expect(component.error).to.equal(false);
       expect(component.users.length).to.equal(2);
     });
 
     it('should show loading indicator while fetching users', async () => {
-      authService.has.resolves(true);
-
       let resolveUsers: any;
       usersService.getUsers.returns(
         new Promise((resolve) => (resolveUsers = resolve)),
       );
-
       fixture.detectChanges();
       await fixture.whenStable();
-
       expect(component.loading).to.equal(true);
-
       resolveUsers([]);
     });
   });


### PR DESCRIPTION
# Description

Addresses PR feedback on the Users module migration.


## Changes

### Route guard on Users route
- Replaced in-component `authService.has('can_configure')` check in `UsersListComponent.ngOnInit()` with the existing `AppRouteGuardProvider`
- Unauthorized users are now redirected to the 403 page before the component loads instead of seeing an empty page
- `ngOnInit` is now `async` and calls `loadUsers()` directly
- `AuthService` dependency removed from `UsersListComponent`

### Token login passthrough
- `EditUserComponent.populateModel()` no longer computes `expired`, `expirationDate`, or `loginDate` client-side
- `tokenLoginEnabled` now stores the raw `token_login` object from the server as-is (`User['token_login'] | null`)
- Template updated to use `expiration_date` directly instead of the previously computed `expired` field

### `oidc_username` added to User interface
- Added `oidc_username?: string` to the `User` interface in `users-interfaces.ts`
- Removed `as any` casts in `EditUserComponent.populateModel()` for `email` and `oidc_username`

## Checklist
- [x] Readable — follows style guide, ESLint passing
- [x] Tested — unit tests updated to reflect removal of AuthService from UsersListComponent
