### PR TITLE
feat(#0041): configure application branding

### DIFF
--- a/admin-tool/src/ts/modules/images/images-branding/images-branding.component.html
+++ b/admin-tool/src/ts/modules/images/images-branding/images-branding.component.html
@@ -15,7 +15,6 @@
           />
           <span class="help-block">{{ 'branding.title.field.help' | translate }}</span>
         </div>
-
         <div class="form-group required">
           <label>{{ 'branding.logo.field' | translate }}</label>
           @if (getImageContent('logo')) {
@@ -35,12 +34,12 @@
             <input
               #logoFile
               type="file"
+              accept="image/*"
               class="hidden-input"
             />
           </div>
           <span class="help-block">{{ 'branding.logo.field.help' | translate }}</span>
         </div>
-
         <div class="form-group required">
           <label>{{ 'branding.favicon.field' | translate }}</label>
           @if (getImageContent('favicon')) {
@@ -58,12 +57,12 @@
             <input
               #faviconFile
               type="file"
+              accept="image/*"
               class="hidden-input"
             />
           </div>
           <span class="help-block">{{ 'branding.favicon.field.help' | translate }}</span>
         </div>
-
         <div class="form-group required">
           <label>{{ 'branding.icon.field' | translate }}</label>
           @if (getImageContent('icon')) {
@@ -81,12 +80,12 @@
             <input
               #iconFile
               type="file"
+              accept="image/*"
               class="hidden-input"
             />
           </div>
           <span class="help-block">{{ 'branding.icon.field.help' | translate }}</span>
         </div>
-
         <div class="form-actions">
           <button
             type="button"

--- a/admin-tool/src/ts/modules/images/images-branding/images-branding.component.html
+++ b/admin-tool/src/ts/modules/images/images-branding/images-branding.component.html
@@ -1,0 +1,107 @@
+<div>
+  @if (loadingPageStatus) {
+    <div class="loader"></div>
+  } @else {
+    <div class="tab-content container-fluid">
+      <form class="custom-form">
+        <div class="form-group required">
+          <label for="title">{{ 'branding.title.field' | translate }}</label>
+          <input
+            id="title"
+            type="text"
+            name="title"
+            class="form-control medium"
+            [(ngModel)]="title"
+          />
+          <span class="help-block">{{ 'branding.title.field.help' | translate }}</span>
+        </div>
+
+        <div class="form-group required">
+          <label>{{ 'branding.logo.field' | translate }}</label>
+          @if (getImageContent('logo')) {
+            <div class="navbar-inverse">
+              <img [src]="getImageContent('logo')" />
+            </div>
+          }
+          <div>
+            <button
+              type="button"
+              class="btn btn-default"
+              (click)="logoFileRef.nativeElement.click()"
+              [disabled]="responseStatus.state === 'loading'">
+              <i class="fa fa-arrow-up" aria-hidden="true"></i>
+              <span>{{ 'Choose file' | translate }}</span>
+            </button>
+            <input
+              #logoFile
+              type="file"
+              class="hidden-input"
+            />
+          </div>
+          <span class="help-block">{{ 'branding.logo.field.help' | translate }}</span>
+        </div>
+
+        <div class="form-group required">
+          <label>{{ 'branding.favicon.field' | translate }}</label>
+          @if (getImageContent('favicon')) {
+            <img [src]="getImageContent('favicon')" />
+          }
+          <div>
+            <button
+              type="button"
+              class="btn btn-default"
+              (click)="faviconFileRef.nativeElement.click()"
+              [disabled]="responseStatus.state === 'loading'">
+              <i class="fa fa-arrow-up" aria-hidden="true"></i>
+              <span>{{ 'Choose file' | translate }}</span>
+            </button>
+            <input
+              #faviconFile
+              type="file"
+              class="hidden-input"
+            />
+          </div>
+          <span class="help-block">{{ 'branding.favicon.field.help' | translate }}</span>
+        </div>
+
+        <div class="form-group required">
+          <label>{{ 'branding.icon.field' | translate }}</label>
+          @if (getImageContent('icon')) {
+            <img [src]="getImageContent('icon')" />
+          }
+          <div>
+            <button
+              type="button"
+              class="btn btn-default"
+              (click)="iconFileRef.nativeElement.click()"
+              [disabled]="responseStatus.state === 'loading'">
+              <i class="fa fa-arrow-up" aria-hidden="true"></i>
+              <span>{{ 'Choose file' | translate }}</span>
+            </button>
+            <input
+              #iconFile
+              type="file"
+              class="hidden-input"
+            />
+          </div>
+          <span class="help-block">{{ 'branding.icon.field.help' | translate }}</span>
+        </div>
+
+        <div class="form-actions">
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="submit()"
+            [disabled]="responseStatus.state === 'loading'">
+            <span>{{ 'Submit' | translate }}</span>
+          </button>
+          @if (responseStatus.state === 'loading') {
+            <div class="loader inline"></div>
+          } @else if (responseStatus.state) {
+            <span [class]="responseStatus.state!">{{ responseStatus.msg! | translate }}</span>
+          }
+        </div>
+      </form>
+    </div>
+  }
+</div>

--- a/admin-tool/src/ts/modules/images/images-branding/images-branding.component.less
+++ b/admin-tool/src/ts/modules/images/images-branding/images-branding.component.less
@@ -1,0 +1,28 @@
+@import (reference) "../../../../css/variables.less";
+
+.hidden-input {
+  display: none;
+}
+
+.form-group {
+  img {
+    display: block;
+    max-height: 3.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .navbar-inverse {
+    display: block;
+    width: fit-content;
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+
+    img {
+      max-height: 3.75rem;
+    }
+  }
+
+  &.required label::after {
+    content: ' *';
+  }
+}

--- a/admin-tool/src/ts/modules/images/images-branding/images-branding.component.less
+++ b/admin-tool/src/ts/modules/images/images-branding/images-branding.component.less
@@ -7,7 +7,6 @@
 .form-group {
   img {
     display: block;
-    max-height: 3.75rem;
     margin-bottom: 0.5rem;
   }
 
@@ -24,5 +23,26 @@
 
   &.required label::after {
     content: ' *';
+  }
+}
+
+.form-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+
+  .loader.inline {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-width: 0.1875rem;
+  }
+
+  .error {
+    color: @red;
+    font-weight: bold;
+    flex-basis: 100%;
+    margin-top: 0.5rem;
   }
 }

--- a/admin-tool/src/ts/modules/images/images-branding/images-branding.component.ts
+++ b/admin-tool/src/ts/modules/images/images-branding/images-branding.component.ts
@@ -1,0 +1,86 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { FormsModule } from '@angular/forms';
+import { BrandingService } from '@admin-tool-services/branding.service';
+import { BrandingDoc } from '@admin-tool-modules/images/images-interfaces';
+import { ResponseStatus } from '@admin-tool-modules/global-modules-interfaces';
+
+/**
+ * Component for managing the application branding configuration in the CHT instance.
+ *
+ * Loads the branding document from CouchDB on init and displays the current
+ * title and image previews for logo, favicon and icon.
+ * Allows administrators to update the application title and upload new images.
+ *
+ * Part of the Images module.
+ */
+@Component({
+  selector: 'images-branding',
+  imports: [TranslatePipe, FormsModule],
+  templateUrl: './images-branding.component.html',
+  styleUrl: './images-branding.component.less'
+})
+export class ImagesBrandingComponent implements OnInit{
+
+  /** Reference to the logo file input element for reading the selected file and resetting after submit */
+  @ViewChild('logoFile') logoFileRef!: ElementRef<HTMLInputElement>;
+
+  /** Reference to the favicon file input element for reading the selected file and resetting after submit */
+  @ViewChild('faviconFile') faviconFileRef!: ElementRef<HTMLInputElement>;
+
+  /** Reference to the icon file input element for reading the selected file and resetting after submit */
+  @ViewChild('iconFile') iconFileRef!: ElementRef<HTMLInputElement>;
+  
+  /** Branding document loaded from CouchDB, used to resolve image previews and for submit operations */
+  brandingDoc: BrandingDoc | null = null;
+
+  /** Controls visibility of the loader while the branding document is being fetched */
+  loadingPageStatus = false;
+
+  /** Tracks the state of the submit operation for loading and error feedback */
+  responseStatus: ResponseStatus = {};
+
+  /** Model for the title input field */
+  title = '';
+
+  constructor(
+    private brandingService: BrandingService,
+    private translate: TranslateService
+  ) { }
+
+  /**
+   * Fetches the branding document from CouchDB on init and initializes
+   * the title input with the current value from the document.
+   */
+  async ngOnInit(): Promise<void> {
+    this.loadingPageStatus = true;
+    
+    try {
+      this.brandingDoc = await this.brandingService.getBranding();
+      this.title = this.brandingDoc.title;
+    } catch (error) {
+      console.error('Error fetching branding document', error);
+    } finally {
+      this.loadingPageStatus = false;
+    }
+  }
+
+  /**
+   * Resolves a logical image key to its data URI using the branding document.
+   * Returns null if the branding document has not loaded yet or if the image
+   * does not exist in the document.
+   *
+   * @param {string} key - the logical image key (e.g. 'logo', 'favicon', 'icon')
+   * @returns {string | null}
+   */
+  getImageContent(key: string): string | null {
+    if (!this.brandingDoc) {
+      return null;
+    }
+    return this.brandingService.getImageContent(key, this.brandingDoc);
+  }
+
+  //TODO
+  async submit(): Promise<void> {}
+
+}

--- a/admin-tool/src/ts/modules/images/images-branding/images-branding.component.ts
+++ b/admin-tool/src/ts/modules/images/images-branding/images-branding.component.ts
@@ -5,6 +5,8 @@ import { BrandingService } from '@admin-tool-services/branding.service';
 import { BrandingDoc } from '@admin-tool-modules/images/images-interfaces';
 import { ResponseStatus } from '@admin-tool-modules/global-modules-interfaces';
 
+const MAX_BRANDING_FILE_SIZE = 100000;
+
 /**
  * Component for managing the application branding configuration in the CHT instance.
  *
@@ -56,8 +58,7 @@ export class ImagesBrandingComponent implements OnInit{
     this.loadingPageStatus = true;
     
     try {
-      this.brandingDoc = await this.brandingService.getBranding();
-      this.title = this.brandingDoc.title;
+      await this.reloadBranding();
     } catch (error) {
       console.error('Error fetching branding document', error);
     } finally {
@@ -85,12 +86,8 @@ export class ImagesBrandingComponent implements OnInit{
    * Called after a successful submit to reflect the updated title and images.
    */
   private async reloadBranding(): Promise<void> {
-    try {
-      this.brandingDoc = await this.brandingService.getBranding();
-      this.title = this.brandingDoc.title;
-    } catch (error) {
-      console.error('Error fetching branding document', error);
-    }
+    this.brandingDoc = await this.brandingService.getBranding();
+    this.title = this.brandingDoc.title;
   }
 
   /**
@@ -113,13 +110,12 @@ export class ImagesBrandingComponent implements OnInit{
       };
       return false;
     }
-    const maxSize = 100000;
     const files = [logo, favicon, icon].filter((file): file is File => !!file);
     for (const file of files) {
-      if (file.size > maxSize) {
+      if (file.size > MAX_BRANDING_FILE_SIZE) {
         this.responseStatus = {
           state: 'error',
-          msg: this.translate.instant('error.file.size', { size: '100KB' })
+          msg: this.translate.instant('error.file.size', { size: `${MAX_BRANDING_FILE_SIZE / 1000}KB` })
         };
         return false;
       }

--- a/admin-tool/src/ts/modules/images/images-branding/images-branding.component.ts
+++ b/admin-tool/src/ts/modules/images/images-branding/images-branding.component.ts
@@ -80,7 +80,80 @@ export class ImagesBrandingComponent implements OnInit{
     return this.brandingService.getImageContent(key, this.brandingDoc);
   }
 
-  //TODO
-  async submit(): Promise<void> {}
+  /**
+   * Reloads the branding document from CouchDB without triggering the full page loader.
+   * Called after a successful submit to reflect the updated title and images.
+   */
+  private async reloadBranding(): Promise<void> {
+    try {
+      this.brandingDoc = await this.brandingService.getBranding();
+      this.title = this.brandingDoc.title;
+    } catch (error) {
+      console.error('Error fetching branding document', error);
+    }
+  }
+
+  /**
+   * Validates the upload form fields before submitting.
+   * Checks that the title is not empty and that no file exceeds the 100KB size limit.
+   * Sets responseStatus to error with the appropriate message on the first failing validation.
+   *
+   * @param {File} [logo] - optional logo file to validate
+   * @param {File} [favicon] - optional favicon file to validate
+   * @param {File} [icon] - optional icon file to validate
+   * @returns {boolean} true if all validations pass, false otherwise
+   */
+  private validateUpload(logo?: File, favicon?: File, icon?: File): boolean {
+    if (!this.title) {
+      this.responseStatus = {
+        state: 'error',
+        msg: this.translate.instant('field is required', {
+          field: this.translate.instant('branding.title.field')
+        })
+      };
+      return false;
+    }
+    const maxSize = 100000;
+    const files = [logo, favicon, icon].filter((file): file is File => !!file);
+    for (const file of files) {
+      if (file.size > maxSize) {
+        this.responseStatus = {
+          state: 'error',
+          msg: this.translate.instant('error.file.size', { size: '100KB' })
+        };
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Saves the branding configuration to CouchDB.
+   * Validates the title and file sizes before proceeding.
+   * Resets all file inputs and reloads the branding document after a successful save.
+   * Sets responseStatus to error if the save fails.
+   */
+  async submit(): Promise<void> {
+    const logo = this.logoFileRef.nativeElement.files?.[0];
+    const favicon = this.faviconFileRef.nativeElement.files?.[0];
+    const icon = this.iconFileRef.nativeElement.files?.[0];
+
+    if (!this.validateUpload(logo, favicon, icon)) {
+      return;
+    }
+
+    this.responseStatus = { state: 'loading' };
+    try {
+      await this.brandingService.updateBranding(this.title, this.brandingDoc!, logo, favicon, icon);
+      this.logoFileRef.nativeElement.value = '';
+      this.faviconFileRef.nativeElement.value = '';
+      this.iconFileRef.nativeElement.value = '';
+      await this.reloadBranding();
+      this.responseStatus = {};
+    } catch (error) {
+      console.error('Error saving branding document', error);
+      this.responseStatus = { state: 'error', msg: 'Error saving settings' };
+    }
+  }
 
 }

--- a/admin-tool/src/ts/modules/images/images-interfaces.ts
+++ b/admin-tool/src/ts/modules/images/images-interfaces.ts
@@ -1,0 +1,23 @@
+/**
+ * Represents a single image attachment in the branding document.
+ * data is only present when the document is fetched with attachments: true.
+ * When writing via put, data can be a File object — PouchDB handles the conversion to base64.
+ */
+export interface BrandingAttachment {
+    content_type: string;
+    data?: string | File;
+}
+
+/**
+ * Represents the branding document as stored in CouchDB.
+ * Contains the application title, a map of logical image names to attachment
+ * filenames, and the attachments themselves.
+ * resources maps logical names (logo, favicon, icon) to their attachment filenames.
+ */
+export interface BrandingDoc {
+    _id: string;
+    title: string;
+    resources: Record<string, string>;
+    _attachments: Record<string, BrandingAttachment>;
+    _rev?: string;
+}

--- a/admin-tool/src/ts/modules/images/images-interfaces.ts
+++ b/admin-tool/src/ts/modules/images/images-interfaces.ts
@@ -4,8 +4,8 @@
  * When writing via put, data can be a File object — PouchDB handles the conversion to base64.
  */
 export interface BrandingAttachment {
-    content_type: string;
-    data?: string | File;
+  content_type: string;
+  data?: string | File;
 }
 
 /**
@@ -15,9 +15,9 @@ export interface BrandingAttachment {
  * resources maps logical names (logo, favicon, icon) to their attachment filenames.
  */
 export interface BrandingDoc {
-    _id: string;
-    title: string;
-    resources: Record<string, string>;
-    _attachments: Record<string, BrandingAttachment>;
-    _rev?: string;
+  _id: string;
+  title: string;
+  resources: Record<string, string>;
+  _attachments: Record<string, BrandingAttachment>;
+  _rev?: string;
 }

--- a/admin-tool/src/ts/modules/images/images.routes.ts
+++ b/admin-tool/src/ts/modules/images/images.routes.ts
@@ -1,7 +1,16 @@
 import { Routes } from '@angular/router';
 import { ImagesHeaderComponent } from './images-header/images-header.component';
 import { ImagesIconsComponent } from './images-icons/images-icons.component';
+import { ImagesBrandingComponent } from './images-branding/images-branding.component';
 
+/**
+ * Routes for the Images module.
+ * Child routes:
+ *   - /images/icons - manage resource icons
+ *   - /images/branding - configure application branding
+ *   - /images/partners - manage partner logos
+ *   - /images/header-tabs-icons - manage header tab icons
+ */
 export const routes: Routes = [
   {
     path: 'images',
@@ -15,6 +24,10 @@ export const routes: Routes = [
       {
         path: 'icons',
         component: ImagesIconsComponent,
+      },
+      {
+        path: 'branding',
+        component: ImagesBrandingComponent,
       },
     ],
   },

--- a/admin-tool/src/ts/services/branding.service.ts
+++ b/admin-tool/src/ts/services/branding.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { DbService } from '@admin-tool-services/db.service';
+import { BrandingAttachment, BrandingDoc } from '@admin-tool-modules/images/images-interfaces';
+
+/**
+ * Service responsible for loading and resolving branding resources from CouchDB.
+ * Branding data is stored in the 'branding' document including the application title
+ * and image attachments for logo, favicon and icon.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class BrandingService {
+
+  constructor(private db: DbService) {}
+
+  /**
+   * Fetches the branding document from CouchDB including all attachment data.
+   * attachments: true is required to retrieve the base64 content of each image.
+   *
+   * @returns {Promise<BrandingDoc>}
+   */
+  async getBranding(): Promise<BrandingDoc> {
+    const doc = await this.db.get().get('branding', { attachments: true });
+    return doc;
+  }
+
+  /**
+   * Resolves a logical image key to its data URI using the branding document.
+   * Returns null if the key does not exist in the resources map, if the attachment
+   * has no data, or if the data is not a base64 string.
+   *
+   * @param {string} key - the logical image key (e.g. 'logo', 'favicon', 'icon')
+   * @param {BrandingDoc} doc - the branding document fetched with attachments: true
+   * @returns {string | null} the data URI string or null if the image cannot be resolved
+   */
+  getImageContent(key: string, doc: BrandingDoc): string | null {
+    const attachmentName = doc.resources[key];
+    if (!attachmentName) {
+      return null;
+    }
+
+    const attachment: BrandingAttachment = doc._attachments[attachmentName];
+    if (!attachment?.data || typeof attachment.data !== 'string') {
+      return null;
+    }
+
+    const content = `data:${attachment.content_type};base64,${attachment.data}`;
+    return content;
+  }
+
+}

--- a/admin-tool/src/ts/services/branding.service.ts
+++ b/admin-tool/src/ts/services/branding.service.ts
@@ -49,4 +49,69 @@ export class BrandingService {
     return content;
   }
 
+  /**
+   * Adds a file as an inline attachment to the branding document and updates
+   * the resources map with the logical key pointing to the new filename.
+   * PouchDB accepts a File object directly in data and handles the base64 conversion.
+   *
+   * @param {File} file - the image file to attach
+   * @param {string} key - the logical image key (e.g. 'logo', 'favicon', 'icon')
+   * @param {BrandingDoc} doc - the branding document to mutate
+   */
+  private updateImage(file: File, key: string, doc: BrandingDoc): void {
+    doc._attachments[file.name] = {
+      content_type: file.type,
+      data: file as any,
+    };
+    doc.resources[key] = file.name;
+  }
+
+  /**
+   * Removes attachments from the branding document that are no longer referenced
+   * in the resources map. Rebuilds the attachments object keeping only the files
+   * currently mapped to logo, favicon and icon.
+   *
+   * @param {BrandingDoc} doc - the branding document to mutate
+   */
+  private removeObsoleteAttachments(doc: BrandingDoc): void {
+    const updatedAttachments: Record<string, BrandingAttachment> = {};
+    ['logo', 'favicon', 'icon'].forEach(key => {
+      const attachmentName = doc.resources[key];
+      if (attachmentName) {
+        updatedAttachments[attachmentName] = doc._attachments[attachmentName];
+      }
+    });
+    doc._attachments = updatedAttachments;
+  }
+
+  /**
+   * Saves the branding configuration to CouchDB.
+   * Fetches a fresh copy of the document to obtain the latest _rev before applying changes.
+   * Updates the title and adds any provided image files as inline attachments.
+   * Removes obsolete attachments before saving to avoid accumulating orphaned files.
+   * All changes are saved in a single put operation.
+   *
+   * @param {string} title - the new application title
+   * @param {BrandingDoc} doc - the current branding document
+   * @param {File} [logo] - optional new logo file
+   * @param {File} [favicon] - optional new favicon file
+   * @param {File} [icon] - optional new icon file
+   * @returns {Promise<void>}
+   */
+  async updateBranding(title: string, doc: BrandingDoc, logo?: File, favicon?: File, icon?: File): Promise<void> {
+    const freshDoc = await this.getBranding();
+    freshDoc.title = title;
+
+    if (logo) {
+      this.updateImage(logo, 'logo', freshDoc);
+    }
+    if (favicon) {
+      this.updateImage(favicon, 'favicon', freshDoc);
+    }
+    if (icon) {
+      this.updateImage(icon, 'icon', freshDoc);
+    }
+    this.removeObsoleteAttachments(freshDoc);
+    await this.db.get().put(freshDoc);
+  }
 }

--- a/admin-tool/tests/karma/ts/modules/images/images-branding.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/images/images-branding.component.spec.ts
@@ -1,0 +1,227 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ImagesBrandingComponent } from '@admin-tool-modules/images/images-branding/images-branding.component';
+import { BrandingService } from '@admin-tool-services/branding.service';
+import { BrandingDoc } from '@admin-tool-modules/images/images-interfaces';
+
+describe('ImagesBrandingComponent', () => {
+  let component: ImagesBrandingComponent;
+  let fixture: ComponentFixture<ImagesBrandingComponent>;
+  let brandingService;
+
+  const mockBrandingDoc: BrandingDoc = {
+    _id: 'branding',
+    _rev: '2-abc123',
+    title: 'Community Health Toolkit',
+    resources: {
+      logo: 'cht-logo.png',
+      favicon: 'favicon.ico',
+    },
+    _attachments: {
+      'cht-logo.png': {
+        content_type: 'image/png',
+        data: btoa('png-content'),
+      },
+      'favicon.ico': {
+        content_type: 'image/x-icon',
+        data: btoa('ico-content'),
+      },
+    },
+  };
+
+  beforeEach(waitForAsync(() => {
+    brandingService = {
+      getBranding: sinon.stub().resolves(mockBrandingDoc),
+      getImageContent: sinon.stub().returns(null),
+    };
+
+    return TestBed.configureTestingModule({
+      imports: [ImagesBrandingComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: BrandingService, useValue: brandingService },
+      ],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(ImagesBrandingComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+  }));
+
+  afterEach(() => sinon.restore());
+
+  describe('initial state', () => {
+    it('should create', () => {
+      expect(component).to.exist;
+    });
+
+    it('should start with loadingPageStatus false', () => {
+      expect(component.loadingPageStatus).to.be.false;
+    });
+
+    it('should start with empty responseStatus', () => {
+      expect(component.responseStatus).to.deep.equal({});
+    });
+  });
+  describe('ngOnInit', () => {
+    it('should call getBranding on init', () => {
+      expect(brandingService.getBranding.calledOnce).to.be.true;
+    });
+
+    it('should set brandingDoc after init', async () => {
+      await fixture.whenStable();
+      expect(component.brandingDoc).to.deep.equal(mockBrandingDoc);
+    });
+
+    it('should set title from branding doc after init', async () => {
+      await fixture.whenStable();
+      expect(component.title).to.equal('Community Health Toolkit');
+    });
+
+    it('should set loadingPageStatus to false after init', async () => {
+      await fixture.whenStable();
+      expect(component.loadingPageStatus).to.be.false;
+    });
+
+    it('should set loadingPageStatus to false even if getBranding fails', async () => {
+      sinon.stub(console, 'error');
+      brandingService.getBranding.rejects(new Error('error'));
+      await component.ngOnInit();
+      expect(component.loadingPageStatus).to.be.false;
+    });
+
+    it('should handle error if getBranding fails', async () => {
+      const consoleStub = sinon.stub(console, 'error');
+      brandingService.getBranding.rejects(new Error('error'));
+      await component.ngOnInit();
+      expect(consoleStub.calledWith('Error fetching branding document', sinon.match.any)).to.be.true;
+    });
+  });
+  describe('getImageContent', () => {
+    it('should return null if brandingDoc is null', () => {
+      component.brandingDoc = null;
+      const result = component.getImageContent('logo');
+      expect(result).to.be.null;
+    });
+
+    it('should call getImageContent from service with correct parameters', async () => {
+      await fixture.whenStable();
+      component.getImageContent('logo');
+      expect(brandingService.getImageContent.calledWith('logo', mockBrandingDoc)).to.be.true;
+    });
+
+    it('should return null when service returns null', async () => {
+      await fixture.whenStable();
+      brandingService.getImageContent.returns(null);
+      const result = component.getImageContent('icon');
+      expect(result).to.be.null;
+    });
+
+    it('should return string when service returns content', async () => {
+      await fixture.whenStable();
+      const dataUri = `data:image/png;base64,${btoa('png-content')}`;
+      brandingService.getImageContent.returns(dataUri);
+      const result = component.getImageContent('logo');
+      expect(result).to.equal(dataUri);
+    });
+  });
+  describe('DOM', () => {
+    it('should show loader when loadingPageStatus is true', () => {
+      component.loadingPageStatus = true;
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.loader')).to.exist;
+    });
+
+    it('should not show loader when loadingPageStatus is false', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.loader')).to.not.exist;
+    });
+
+    it('should render title input', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('#title')).to.exist;
+    });
+
+    it('should render logo preview when getImageContent returns content', async () => {
+      await fixture.whenStable();
+      brandingService.getImageContent.returns(`data:image/png;base64,${btoa('png-content')}`);
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.navbar-inverse img')).to.exist;
+    });
+
+    it('should not render logo preview when getImageContent returns null', async () => {
+      await fixture.whenStable();
+      brandingService.getImageContent.returns(null);
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.navbar-inverse img')).to.not.exist;
+    });
+
+    it('should render favicon preview when getImageContent returns content', async () => {
+      await fixture.whenStable();
+      brandingService.getImageContent.returns(`data:image/x-icon;base64,${btoa('ico-content')}`);
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      const images = compiled.querySelectorAll('.form-group img');
+      expect(images.length).to.be.greaterThan(0);
+    });
+
+    it('should render three choose file buttons', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      const buttons = compiled.querySelectorAll('button.btn-default');
+      expect(buttons.length).to.equal(3);
+    });
+
+    it('should render submit button', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('button.btn-primary')).to.exist;
+    });
+
+    it('should disable submit button when responseStatus is loading', async () => {
+      await fixture.whenStable();
+      component.responseStatus = { state: 'loading' };
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      const button = compiled.querySelector('button.btn-primary') as HTMLButtonElement;
+      expect(button.disabled).to.be.true;
+    });
+
+    it('should disable choose file buttons when responseStatus is loading', async () => {
+      await fixture.whenStable();
+      component.responseStatus = { state: 'loading' };
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      const buttons = compiled.querySelectorAll<HTMLButtonElement>('button.btn-default');
+      buttons.forEach(button => expect(button.disabled).to.be.true);
+    });
+
+    it('should show inline loader when responseStatus is loading', async () => {
+      await fixture.whenStable();
+      component.responseStatus = { state: 'loading' };
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.loader.inline')).to.exist;
+    });
+
+    it('should show error message when responseStatus is error', async () => {
+      await fixture.whenStable();
+      component.responseStatus = { state: 'error', msg: 'Error saving settings' };
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.error')).to.exist;
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/modules/images/images-branding.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/images/images-branding.component.spec.ts
@@ -35,6 +35,7 @@ describe('ImagesBrandingComponent', () => {
     brandingService = {
       getBranding: sinon.stub().resolves(mockBrandingDoc),
       getImageContent: sinon.stub().returns(null),
+      updateBranding: sinon.stub().resolves(),
     };
 
     return TestBed.configureTestingModule({
@@ -126,6 +127,113 @@ describe('ImagesBrandingComponent', () => {
       brandingService.getImageContent.returns(dataUri);
       const result = component.getImageContent('logo');
       expect(result).to.equal(dataUri);
+    });
+  });
+  describe('submit', () => {
+    beforeEach(async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    const setFiles = (logoFile: File | null, faviconFile: File | null, iconFile: File | null) => {
+      Object.defineProperty(component.logoFileRef.nativeElement, 'files', {
+        value: logoFile ? [logoFile] : [],
+        configurable: true,
+      });
+      Object.defineProperty(component.faviconFileRef.nativeElement, 'files', {
+        value: faviconFile ? [faviconFile] : [],
+        configurable: true,
+      });
+      Object.defineProperty(component.iconFileRef.nativeElement, 'files', {
+        value: iconFile ? [iconFile] : [],
+        configurable: true,
+      });
+    };
+
+    it('should set error if title is empty', async () => {
+      component.title = '';
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+    });
+
+    it('should set error if logo file is larger than 100KB', async () => {
+      const file = new File([new ArrayBuffer(100001)], 'logo.png', { type: 'image/png' });
+      setFiles(file, null, null);
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+    });
+
+    it('should set error if favicon file is larger than 100KB', async () => {
+      const file = new File([new ArrayBuffer(100001)], 'favicon.ico', { type: 'image/x-icon' });
+      setFiles(null, file, null);
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+    });
+
+    it('should set error if icon file is larger than 100KB', async () => {
+      const file = new File([new ArrayBuffer(100001)], 'icon.png', { type: 'image/png' });
+      setFiles(null, null, file);
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+    });
+
+    it('should set responseStatus to loading during submit', async () => {
+      brandingService.updateBranding.callsFake(() => {
+        expect(component.responseStatus.state).to.equal('loading');
+        return Promise.resolve();
+      });
+      setFiles(null, null, null);
+      await component.submit();
+    });
+
+    it('should call updateBranding with correct arguments', async () => {
+      const logo = new File([''], 'new-logo.png', { type: 'image/png' });
+      setFiles(logo, null, null);
+      await component.submit();
+      expect(brandingService.updateBranding.calledWith(
+        'Community Health Toolkit',
+        mockBrandingDoc,
+        logo,
+        undefined,
+        undefined
+      )).to.be.true;
+    });
+
+    it('should reset file inputs after success', async () => {
+      setFiles(null, null, null);
+      await component.submit();
+      expect(component.logoFileRef.nativeElement.value).to.equal('');
+      expect(component.faviconFileRef.nativeElement.value).to.equal('');
+      expect(component.iconFileRef.nativeElement.value).to.equal('');
+    });
+
+    it('should call getBranding more than once after success', async () => {
+      setFiles(null, null, null);
+      await component.submit();
+      expect(brandingService.getBranding.callCount).to.be.greaterThan(1);
+    });
+
+    it('should clear responseStatus after success', async () => {
+      setFiles(null, null, null);
+      await component.submit();
+      expect(component.responseStatus).to.deep.equal({});
+    });
+
+    it('should set error responseStatus if updateBranding fails', async () => {
+      brandingService.updateBranding.rejects(new Error('error'));
+      sinon.stub(console, 'error');
+      setFiles(null, null, null);
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+      expect(component.responseStatus.msg).to.equal('Error saving settings');
+    });
+
+    it('should call console.error if updateBranding fails', async () => {
+      brandingService.updateBranding.rejects(new Error('error'));
+      const consoleStub = sinon.stub(console, 'error');
+      setFiles(null, null, null);
+      await component.submit();
+      expect(consoleStub.calledWith('Error saving branding document', sinon.match.any)).to.be.true;
     });
   });
   describe('DOM', () => {

--- a/admin-tool/tests/karma/ts/services/branding.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/branding.service.spec.ts
@@ -1,0 +1,133 @@
+import { TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BrandingService } from '@admin-tool-services/branding.service';
+import { DbService } from '@admin-tool-services/db.service';
+import { BrandingDoc } from '@admin-tool-modules/images/images-interfaces';
+
+describe('BrandingService', () => {
+  let service: BrandingService;
+  let dbService;
+
+  const mockBrandingDoc: BrandingDoc = {
+    _id: 'branding',
+    _rev: '2-abc123',
+    title: 'Community Health Toolkit',
+    resources: {
+      logo: 'cht-logo.png',
+      favicon: 'favicon.ico',
+    },
+    _attachments: {
+      'cht-logo.png': {
+        content_type: 'image/png',
+        data: btoa('png-content'),
+      },
+      'favicon.ico': {
+        content_type: 'image/x-icon',
+        data: btoa('ico-content'),
+      },
+    },
+  };
+
+  beforeEach(() => {
+    dbService = {
+      get: sinon.stub().returns({
+        get: sinon.stub().resolves(mockBrandingDoc),
+        put: sinon.stub().resolves(),
+      }),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: DbService, useValue: dbService },
+      ],
+    });
+
+    service = TestBed.inject(BrandingService);
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('getBranding', () => {
+    it('should call db.get with correct document id and attachments option', async () => {
+      await service.getBranding();
+      expect(dbService.get().get.calledWith('branding', { attachments: true })).to.be.true;
+    });
+
+    it('should return the branding doc', async () => {
+      const result = await service.getBranding();
+      expect(result._id).to.equal('branding');
+    });
+
+    it('should return the title', async () => {
+      const result = await service.getBranding();
+      expect(result.title).to.equal('Community Health Toolkit');
+    });
+
+    it('should return the resources map', async () => {
+      const result = await service.getBranding();
+      expect(result.resources).to.deep.equal(mockBrandingDoc.resources);
+    });
+
+    it('should propagate error if db.get fails', async () => {
+      dbService.get().get.rejects(new Error('error'));
+      try {
+        await service.getBranding();
+        expect.fail('should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.equal('error');
+      }
+    });
+  });
+  describe('getImageContent', () => {
+    it('should return data URI for png image', () => {
+      const result = service.getImageContent('logo', mockBrandingDoc);
+      expect(result).to.equal(`data:image/png;base64,${btoa('png-content')}`);
+    });
+
+    it('should return data URI for ico image', () => {
+      const result = service.getImageContent('favicon', mockBrandingDoc);
+      expect(result).to.equal(`data:image/x-icon;base64,${btoa('ico-content')}`);
+    });
+
+    it('should return null if key does not exist in resources', () => {
+      const result = service.getImageContent('icon', mockBrandingDoc);
+      expect(result).to.be.null;
+    });
+
+    it('should return null if attachment has no data', () => {
+      const docWithoutData: BrandingDoc = {
+        ...mockBrandingDoc,
+        _attachments: {
+          'cht-logo.png': { content_type: 'image/png' }
+        }
+      };
+      const result = service.getImageContent('logo', docWithoutData);
+      expect(result).to.be.null;
+    });
+
+    it('should return null if attachment data is a File', () => {
+      const docWithFile: BrandingDoc = {
+        ...mockBrandingDoc,
+        _attachments: {
+          'cht-logo.png': {
+            content_type: 'image/png',
+            data: new File([''], 'logo.png', { type: 'image/png' }) as any
+          }
+        }
+      };
+      const result = service.getImageContent('logo', docWithFile);
+      expect(result).to.be.null;
+    });
+
+    it('should return null if resources map is empty', () => {
+      const emptyDoc: BrandingDoc = {
+        ...mockBrandingDoc,
+        resources: {},
+        _attachments: {}
+      };
+      const result = service.getImageContent('logo', emptyDoc);
+      expect(result).to.be.null;
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/branding.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/branding.service.spec.ts
@@ -32,7 +32,7 @@ describe('BrandingService', () => {
   beforeEach(() => {
     dbService = {
       get: sinon.stub().returns({
-        get: sinon.stub().resolves(mockBrandingDoc),
+        get: sinon.stub().callsFake(() => Promise.resolve(JSON.parse(JSON.stringify(mockBrandingDoc)))),
         put: sinon.stub().resolves(),
       }),
     };
@@ -128,6 +128,81 @@ describe('BrandingService', () => {
       };
       const result = service.getImageContent('logo', emptyDoc);
       expect(result).to.be.null;
+    });
+  });
+  describe('updateBranding', () => {
+    it('should call getBranding to fetch the current doc', async () => {
+      await service.updateBranding('New Title', mockBrandingDoc);
+      expect(dbService.get().get.calledWith('branding', { attachments: true })).to.be.true;
+    });
+
+    it('should update the title in the doc', async () => {
+      await service.updateBranding('New Title', mockBrandingDoc);
+      const doc = dbService.get().put.args[0][0];
+      expect(doc.title).to.equal('New Title');
+    });
+
+    it('should call db.put with the updated doc', async () => {
+      await service.updateBranding('New Title', mockBrandingDoc);
+      expect(dbService.get().put.calledOnce).to.be.true;
+    });
+
+    it('should add logo attachment when logo file is provided', async () => {
+      const file = new File([''], 'new-logo.png', { type: 'image/png' });
+      await service.updateBranding('New Title', mockBrandingDoc, file);
+      const doc = dbService.get().put.args[0][0];
+      expect(doc._attachments['new-logo.png'].content_type).to.equal('image/png');
+      expect(doc.resources['logo']).to.equal('new-logo.png');
+    });
+
+    it('should add favicon attachment when favicon file is provided', async () => {
+      const file = new File([''], 'new-favicon.ico', { type: 'image/x-icon' });
+      await service.updateBranding('New Title', mockBrandingDoc, undefined, file);
+      const doc = dbService.get().put.args[0][0];
+      expect(doc._attachments['new-favicon.ico'].content_type).to.equal('image/x-icon');
+      expect(doc.resources['favicon']).to.equal('new-favicon.ico');
+    });
+
+    it('should add icon attachment when icon file is provided', async () => {
+      const file = new File([''], 'new-icon.png', { type: 'image/png' });
+      await service.updateBranding('New Title', mockBrandingDoc, undefined, undefined, file);
+      const doc = dbService.get().put.args[0][0];
+      expect(doc._attachments['new-icon.png'].content_type).to.equal('image/png');
+      expect(doc.resources['icon']).to.equal('new-icon.png');
+    });
+
+    it('should remove obsolete attachments after update', async () => {
+      const file = new File([''], 'new-logo.png', { type: 'image/png' });
+      await service.updateBranding('New Title', mockBrandingDoc, file);
+      const doc = dbService.get().put.args[0][0];
+      expect(doc._attachments['cht-logo.png']).to.be.undefined;
+    });
+
+    it('should keep existing attachments that are still referenced', async () => {
+      await service.updateBranding('New Title', mockBrandingDoc);
+      const doc = dbService.get().put.args[0][0];
+      expect(doc._attachments['cht-logo.png']).to.exist;
+      expect(doc._attachments['favicon.ico']).to.exist;
+    });
+
+    it('should propagate error if getBranding fails', async () => {
+      dbService.get().get.rejects(new Error('error'));
+      try {
+        await service.updateBranding('New Title', mockBrandingDoc);
+        expect.fail('should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.equal('error');
+      }
+    });
+
+    it('should propagate error if db.put fails', async () => {
+      dbService.get().put.rejects(new Error('put error'));
+      try {
+        await service.updateBranding('New Title', mockBrandingDoc);
+        expect.fail('should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.equal('put error');
+      }
     });
   });
 });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->
## Description
 
Implements the Branding tab in the Images section of the admin tool. Administrators can view and update the application title, logo, favicon and large icon from the branding CouchDB document. Images are displayed as previews with the logo shown in its navbar context. The form validates the title as required and enforces a 100KB size limit per image file before saving all changes to CouchDB in a single operation.
 
**Changes include:**
- Added BrandingDoc and BrandingAttachment interfaces to images-interfaces.ts to represent the branding CouchDB document structure
- Added BrandingService with getBranding to fetch the branding document with attachments, getImageContent to resolve logical image keys to data URIs, updateImage to add file attachments inline to the document, removeObsoleteAttachments to clean up orphaned attachments after an update, and updateBranding to apply all changes and save in a single put operation
- Added ImagesBrandingComponent with ngOnInit to load the branding document and initialize the title input, getImageContent as a wrapper to resolve image previews from the template, validateUpload to validate the title field and file sizes in order, reloadBranding to refresh the document after a successful submit without triggering the page loader, and submit to orchestrate the full save flow with loading state, input reset on success and error feedback on failure
- Added the branding route to images.routes.ts
- Added unit tests for BrandingService and ImagesBrandingComponent

<img width="1055" height="291" alt="Screenshot 2026-05-06 at 3 37 03 PM" src="https://github.com/user-attachments/assets/3a4897af-3d64-4532-8361-14205eec4888" />
<img width="797" height="790" alt="Screenshot 2026-05-06 at 3 38 34 PM" src="https://github.com/user-attachments/assets/038a9680-d352-4ddf-8047-37cf4ef0f5a0" />
<img width="797" height="790" alt="Screenshot 2026-05-06 at 3 38 48 PM" src="https://github.com/user-attachments/assets/c7a67edc-77ae-40da-8fe1-72e323e7424c" />
<img width="797" height="790" alt="Screenshot 2026-05-06 at 3 38 55 PM" src="https://github.com/user-attachments/assets/1397a12d-4450-4b74-b07f-3a6e4ee8ab9b" />
<img width="797" height="546" alt="Screenshot 2026-05-06 at 3 39 40 PM" src="https://github.com/user-attachments/assets/6f2d1353-58aa-4c94-bc35-0a1d6f812932" />


<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

