### PR TITLE
feat(#33): add SMS test component with routing and unit tests

### DIFF
--- a/admin-tool/src/ts/modules/sms/sms-test/sms-test-interfaces.ts
+++ b/admin-tool/src/ts/modules/sms/sms-test/sms-test-interfaces.ts
@@ -1,0 +1,4 @@
+export interface SmsTestErrors {
+  message?: string;
+  from?: string;
+}

--- a/admin-tool/src/ts/modules/sms/sms-test/sms-test.component.html
+++ b/admin-tool/src/ts/modules/sms/sms-test/sms-test.component.html
@@ -1,0 +1,49 @@
+<div class="sms-configuration-container">
+  <div class="col-xs-8 configuration-form">
+    <p>{{ 'configuration.sms.test.description' | translate }}</p>
+
+    <div class="form-group required" [ngClass]="{ 'has-error': errors.message }">
+      <label for="message">{{ 'Message Body' | translate }}</label>
+      <input
+        id="message"
+        type="text"
+        class="form-control"
+        [(ngModel)]="message"
+        name="message"
+      />
+      <span class="help-block">{{ 'configuration.sms.test.message.description' | translate }}</span>
+      @if (errors.message) {
+        <span class="help-block">{{ errors.message | translate }}</span>
+      }
+    </div>
+
+    <div class="form-group required" [ngClass]="{ 'has-error': errors.from }">
+      <label for="from">{{ 'configuration.sms.test.from.number' | translate }}</label>
+      <input
+        id="from"
+        type="text"
+        class="form-control small"
+        [(ngModel)]="from"
+        name="from"
+      />
+      <span class="help-block">{{ 'configuration.sms.test.number.validation.description' | translate }}</span>
+      @if (errors.from) {
+        <span class="help-block">{{ errors.from | translate }}</span>
+      }
+    </div>
+
+    <button
+      type="button"
+      class="btn btn-primary"
+      (click)="submit()"
+      [disabled]="saving"
+    >{{ 'Send Message' | translate }}</button>
+
+    @if (success) {
+      <span>{{ 'report.created' | translate }}</span>
+    }
+    @if (failure) {
+      <span>{{ 'Error sending message' | translate }}</span>
+    }
+  </div>
+</div>

--- a/admin-tool/src/ts/modules/sms/sms-test/sms-test.component.ts
+++ b/admin-tool/src/ts/modules/sms/sms-test/sms-test.component.ts
@@ -1,0 +1,99 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { SmsTestErrors } from './sms-test-interfaces';
+
+@Component({
+  selector: 'sms-test',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslateModule],
+  templateUrl: './sms-test.component.html',
+})
+export class SmsTestComponent {
+
+  /** The message body to send */
+  message = '';
+
+  /** The sender phone number */
+  from = '';
+
+  /** Validation errors for the form fields */
+  errors: SmsTestErrors = {};
+
+  /** Controls the disabled state of the Send Message button */
+  saving = false;
+
+  /** True when the message was sent successfully */
+  success = false;
+
+  /** True when the message failed to send */
+  failure = false;
+
+  constructor(private readonly http: HttpClient) {}
+
+  /**
+   * Validates the form, sends the test SMS via the API,
+   * and updates the success or failure state accordingly.
+   */
+  submit(): void {
+    this.success = false;
+    this.failure = false;
+
+    if (!this.validate()) {
+      return;
+    }
+
+    this.saving = true;
+    this.send()
+      .then(() => {
+        this.success = true;
+        this.saving = false;
+      })
+      .catch(err => {
+        this.failure = true;
+        this.saving = false;
+        console.error('Error submitting message', err);
+      });
+  }
+
+  /**
+   * Validates that message and from fields are not empty.
+   * Populates the errors object with translation keys for any missing fields.
+   *
+   * @returns {boolean} true if the form is valid
+   */
+  private validate(): boolean {
+    this.errors = {};
+    if (!this.message) {
+      this.errors.message = 'validate.required';
+    }
+    if (!this.from) {
+      this.errors.from = 'validate.required';
+    }
+    return !this.errors.message && !this.errors.from;
+  }
+
+  /**
+   * Sends the test SMS to the CHT API.
+   * Posts to /api/v2/records with form-encoded body.
+   *
+   * @returns {Promise<void>}
+   */
+  private send(): Promise<void> {
+    const body = new HttpParams()
+      .set('message', this.message)
+      .set('from', this.from);
+
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/x-www-form-urlencoded',
+    });
+
+    return this.http
+      .post('/api/v2/records', body.toString(), { headers })
+      .toPromise()
+      .then(() => undefined);
+  }
+}

--- a/admin-tool/src/ts/modules/sms/sms.routes.ts
+++ b/admin-tool/src/ts/modules/sms/sms.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { SmsComponent } from './sms.component';
 import { SmsSettingsComponent } from './sms-settings/sms-settings.component';
+import { SmsTestComponent } from './sms-test/sms-test.component';
 
 /**
  * Routes for the SMS module.
@@ -22,6 +23,10 @@ export const routes: Routes = [
       {
         path: 'settings',
         component: SmsSettingsComponent,
+      },
+      {
+        path: 'test',
+        component: SmsTestComponent,
       },
     ],
   },

--- a/admin-tool/tests/karma/ts/modules/sms/sms-test.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/sms/sms-test.component.spec.ts
@@ -1,0 +1,241 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { TranslateModule } from '@ngx-translate/core';
+import { SmsTestComponent } from '@admin-tool-modules/sms/sms-test/sms-test.component';
+
+describe('SmsTestComponent', () => {
+  let component: SmsTestComponent;
+  let fixture: ComponentFixture<SmsTestComponent>;
+  let httpMock: HttpTestingController;
+
+  const stabilize = async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await fixture.whenStable();
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SmsTestComponent, TranslateModule.forRoot()],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SmsTestComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    sinon.restore();
+  });
+
+  // --- ZERO ---
+  describe('Zero', () => {
+    it('should initialise with empty fields and clean state', () => {
+      expect(component.message).to.equal('');
+      expect(component.from).to.equal('');
+      expect(component.saving).to.equal(false);
+      expect(component.success).to.equal(false);
+      expect(component.failure).to.equal(false);
+      expect(Object.keys(component.errors)).to.have.length(0);
+    });
+  });
+
+  // --- ONE ---
+  describe('One', () => {
+    it('should set message error when message is empty on submit', () => {
+      component.from = '+50612345678';
+      component.submit();
+      expect(component.errors.message).to.equal('validate.required');
+    });
+
+    it('should set from error when from is empty on submit', () => {
+      component.message = 'Test message';
+      component.submit();
+      expect(component.errors.from).to.equal('validate.required');
+    });
+
+    it('should send request to /api/v2/records on valid submit', async () => {
+      component.message = 'Test message';
+      component.from = '+50612345678';
+      component.submit();
+
+      const req = httpMock.expectOne('/api/v2/records');
+      expect(req.request.method).to.equal('POST');
+      req.flush({});
+      await stabilize();
+    });
+
+    it('should set success true after successful send', async () => {
+      component.message = 'Test message';
+      component.from = '+50612345678';
+      component.submit();
+
+      httpMock.expectOne('/api/v2/records').flush({});
+      await stabilize();
+
+      expect(component.success).to.equal(true);
+      expect(component.failure).to.equal(false);
+    });
+  });
+
+  // --- MANY ---
+  describe('Many', () => {
+    it('should set both errors when both fields are empty', () => {
+      component.submit();
+      expect(component.errors.message).to.equal('validate.required');
+      expect(component.errors.from).to.equal('validate.required');
+    });
+
+    it('should clear previous errors on each submit attempt', () => {
+      component.submit();
+      expect(component.errors.message).to.exist;
+
+      component.message = 'Test message';
+      component.from = '+50612345678';
+      component.submit();
+      httpMock.expectOne('/api/v2/records').flush({});
+      expect(component.errors.message).to.not.exist;
+      expect(component.errors.from).to.not.exist;
+    });
+  });
+
+  // --- BOUNDARIES ---
+  describe('Boundaries', () => {
+    it('should not call API when validation fails', () => {
+      component.submit();
+      httpMock.expectNone('/api/v2/records');
+    });
+
+    it('should set saving to true while request is in flight', () => {
+      component.message = 'Test message';
+      component.from = '+50612345678';
+      component.submit();
+      expect(component.saving).to.equal(true);
+      httpMock.expectOne('/api/v2/records').flush({});
+    });
+
+    it('should set saving to false after successful send', async () => {
+      component.message = 'Test message';
+      component.from = '+50612345678';
+      component.submit();
+      httpMock.expectOne('/api/v2/records').flush({});
+      await stabilize();
+      expect(component.saving).to.equal(false);
+    });
+
+    it('should set saving to false after failed send', async () => {
+      component.message = 'Test message';
+      component.from = '+50612345678';
+      component.submit();
+      httpMock.expectOne('/api/v2/records').flush({}, { status: 500, statusText: 'Server Error' });
+      await stabilize();
+      expect(component.saving).to.equal(false);
+    });
+  });
+
+  // --- INTERFACE ---
+  describe('Interface', () => {
+    it('should send message and from as form-encoded body', async () => {
+      component.message = 'Hello CHT';
+      component.from = '+50612345678';
+      component.submit();
+
+      const req = httpMock.expectOne('/api/v2/records');
+      expect(req.request.body).to.include('message=Hello%20CHT');
+      expect(req.request.body).to.include('from=%2B50612345678');
+      req.flush({});
+      await stabilize();
+    });
+
+    it('should send with Content-Type application/x-www-form-urlencoded', async () => {
+      component.message = 'Test';
+      component.from = '+506';
+      component.submit();
+
+      const req = httpMock.expectOne('/api/v2/records');
+      expect(req.request.headers.get('Content-Type')).to.equal('application/x-www-form-urlencoded');
+      req.flush({});
+      await stabilize();
+    });
+
+    it('should reset success and failure flags on each submit', async () => {
+      component.message = 'Test';
+      component.from = '+506';
+      component.success = true;
+      component.failure = true;
+      component.submit();
+
+      expect(component.success).to.equal(false);
+      expect(component.failure).to.equal(false);
+      httpMock.expectOne('/api/v2/records').flush({});
+      await stabilize();
+    });
+
+    it('should disable the send button while saving', async () => {
+      await stabilize();
+      component.saving = true;
+      fixture.detectChanges();
+      const button = fixture.nativeElement.querySelector('button[disabled]');
+      expect(button).to.exist;
+    });
+  });
+
+  // --- EXCEPTIONS ---
+  describe('Exceptions', () => {
+    it('should set failure true when API returns an error', async () => {
+      const consoleStub = sinon.stub(console, 'error');
+      component.message = 'Test message';
+      component.from = '+50612345678';
+      component.submit();
+
+      httpMock.expectOne('/api/v2/records').flush({}, { status: 500, statusText: 'Server Error' });
+      await stabilize();
+
+      expect(component.failure).to.equal(true);
+      expect(component.success).to.equal(false);
+      expect(consoleStub.callCount).to.be.greaterThan(0);
+    });
+  });
+
+  // --- SCENARIOS ---
+  describe('Scenarios', () => {
+    it('should complete full happy path: fill fields → submit → success', async () => {
+      await stabilize();
+
+      component.message = 'Test SMS';
+      component.from = '+50612345678';
+      component.submit();
+
+      expect(component.saving).to.equal(true);
+      httpMock.expectOne('/api/v2/records').flush({});
+      await stabilize();
+
+      expect(component.success).to.equal(true);
+      expect(component.saving).to.equal(false);
+      expect(component.failure).to.equal(false);
+    });
+
+    it('should show error message in template when failure is true', async () => {
+      component.failure = true;
+      await stabilize();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).to.include('Error sending message');
+    });
+
+    it('should show required errors in template when fields are empty', async () => {
+      component.submit();
+      await stabilize();
+      const helpBlocks = fixture.nativeElement.querySelectorAll('.help-block');
+      expect(helpBlocks.length).to.be.greaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Migrates the SMS Test tab from the legacy AngularJS admin app to Angular 19 as part of the ongoing admin tool upgrade.

Closes #33

Changes included:
- Added `SmsTestComponent` with message body and from number fields
- Validation: both fields required, inline errors shown when empty
- Send Message button disabled while request is in flight
- Success and failure states shown after API response
- Posts to `/api/v2/records` with `application/x-www-form-urlencoded` encoding
- Added `/sms/test` child route to `sms.routes.ts`
- Added unit tests following ZOMBIES methodology

# Code review checklist
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages.
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
<img width="1447" height="567" alt="Screenshot 2026-05-08 at 2 23 11 PM" src="https://github.com/user-attachments/assets/a3425d49-f74e-4eb9-99dc-302681ef2fc9" />
