### PR TITLE
feat(#0043): add manage partner logos

### DIFF
--- a/admin-tool/src/ts/modules/images/images-branding/images-branding.component.ts
+++ b/admin-tool/src/ts/modules/images/images-branding/images-branding.component.ts
@@ -140,7 +140,7 @@ export class ImagesBrandingComponent implements OnInit{
 
     this.responseStatus = { state: 'loading' };
     try {
-      await this.brandingService.updateBranding(this.title, this.brandingDoc!, logo, favicon, icon);
+      await this.brandingService.updateBranding(this.title, logo, favicon, icon);
       this.logoFileRef.nativeElement.value = '';
       this.faviconFileRef.nativeElement.value = '';
       this.iconFileRef.nativeElement.value = '';

--- a/admin-tool/src/ts/modules/images/images-interfaces.ts
+++ b/admin-tool/src/ts/modules/images/images-interfaces.ts
@@ -21,3 +21,16 @@ export interface BrandingDoc {
   _attachments: Record<string, BrandingAttachment>;
   _rev?: string;
 }
+
+/**
+ * Represents the partners document as stored in CouchDB.
+ * Contains a map of partner names to attachment filenames and the attachments themselves.
+ * resources maps partner names (e.g. 'apple') to their attachment filenames (e.g. 'apple-logo.png').
+ * If the document does not exist in CouchDB, an empty doc is returned instead of throwing.
+ */
+export interface PartnersDoc {
+  _id: string;
+  resources: Record<string, string>;
+  _attachments: Record<string, BrandingAttachment>;
+  _rev?: string;
+}

--- a/admin-tool/src/ts/modules/images/images-partners/images-partners.component.html
+++ b/admin-tool/src/ts/modules/images/images-partners/images-partners.component.html
@@ -58,7 +58,7 @@
           <ul class="list-inline">
             @for (key of partners; track key) {
               <li>
-                <img [src]="getImageContent(key)" [alt]="key" />
+                <img [src]="getImageContent(key)" [alt]="" />
               </li>
             }
           </ul>

--- a/admin-tool/src/ts/modules/images/images-partners/images-partners.component.html
+++ b/admin-tool/src/ts/modules/images/images-partners/images-partners.component.html
@@ -1,0 +1,69 @@
+<div>
+  @if (loadingPageStatus) {
+    <div class="loader"></div>
+  } @else {
+    <div class="tab-content container-fluid">
+      <p>{{ 'images.partners.description' | translate }}</p>
+      <div class="section">
+        <legend>{{ 'partner.logo.upload' | translate }}</legend>
+        <form class="custom-form">
+          <div class="form-group required">
+            <label for="name">{{ 'partner.name.field' | translate }}</label>
+            <input
+              id="name"
+              type="text"
+              name="name"
+              class="form-control medium"
+              [(ngModel)]="name"
+            />
+          </div>
+          <div class="form-group required">
+            <label>{{ 'partner.logo.field' | translate }}</label>
+            <div>
+              <button
+                type="button"
+                class="btn btn-default"
+                (click)="logoFileRef.nativeElement.click()"
+                [disabled]="responseStatus.state === 'loading'">
+                <i class="fa fa-arrow-up" aria-hidden="true"></i>
+                <span>{{ 'Choose file' | translate }}</span>
+              </button>
+              <input
+                #logoFile
+                type="file"
+                accept="image/*"
+                class="hidden-input"
+              />
+            </div>
+          </div>
+          <div class="form-actions">
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="submit()"
+              [disabled]="responseStatus.state === 'loading'">
+              <span>{{ 'Submit' | translate }}</span>
+            </button>
+            @if (responseStatus.state === 'loading') {
+              <div class="loader inline"></div>
+            } @else if (responseStatus.state) {
+              <span [class]="responseStatus.state!">{{ responseStatus.msg! | translate }}</span>
+            }
+          </div>
+        </form>
+      </div>
+      @if (partners.length) {
+        <div class="section">
+          <legend>{{ 'partner.tab.partners' | translate }}</legend>
+          <ul class="list-inline">
+            @for (key of partners; track key) {
+              <li>
+                <img [src]="getImageContent(key)" [alt]="key" />
+              </li>
+            }
+          </ul>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/admin-tool/src/ts/modules/images/images-partners/images-partners.component.less
+++ b/admin-tool/src/ts/modules/images/images-partners/images-partners.component.less
@@ -3,13 +3,11 @@
 .hidden-input {
   display: none;
 }
-
 .form-group {
   &.required label::after {
     content: ' *';
   }
 }
-
 .form-actions {
   display: flex;
   flex-direction: row;
@@ -30,7 +28,6 @@
     margin-top: 0.5rem;
   }
 }
-
 .section {
   margin-bottom: 1rem;
 
@@ -41,7 +38,6 @@
     margin-bottom: 1.5rem;
   }
 }
-
 .list-inline {
   li {
     img {

--- a/admin-tool/src/ts/modules/images/images-partners/images-partners.component.less
+++ b/admin-tool/src/ts/modules/images/images-partners/images-partners.component.less
@@ -1,0 +1,54 @@
+@import (reference) "../../../../css/variables.less";
+
+.hidden-input {
+  display: none;
+}
+
+.form-group {
+  &.required label::after {
+    content: ' *';
+  }
+}
+
+.form-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+
+  .loader.inline {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-width: 0.1875rem;
+  }
+
+  .error {
+    color: @red;
+    font-weight: bold;
+    flex-basis: 100%;
+    margin-top: 0.5rem;
+  }
+}
+
+.section {
+  margin-bottom: 1rem;
+
+  legend {
+    font-size: 1.625rem;
+    color: @gray-dark;
+    border-bottom: 0.0625rem solid @gray-light;
+    margin-bottom: 1.5rem;
+  }
+}
+
+.list-inline {
+  li {
+    img {
+      display: inline-block;
+      max-height: 9.375rem;
+      max-width: 9.375rem;
+      margin: 2.5rem;
+    }
+  }
+}

--- a/admin-tool/src/ts/modules/images/images-partners/images-partners.component.ts
+++ b/admin-tool/src/ts/modules/images/images-partners/images-partners.component.ts
@@ -87,6 +87,7 @@ export class ImagesPartnersComponent implements OnInit {
     }
     return this.partnersService.getImageContent(key, this.partnersDoc);
   }
+  
   /**
    * Validates the upload form fields before submitting.
    * Checks in order: name provided, file selected, file size under 1MB.

--- a/admin-tool/src/ts/modules/images/images-partners/images-partners.component.ts
+++ b/admin-tool/src/ts/modules/images/images-partners/images-partners.component.ts
@@ -1,0 +1,95 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { FormsModule } from '@angular/forms';
+import { PartnersService } from '@admin-tool-services/partners.service';
+import { PartnersDoc } from '@admin-tool-modules/images/images-interfaces';
+import { ResponseStatus } from '@admin-tool-modules/global-modules-interfaces';
+
+const MAX_PARTNERS_FILE_SIZE = 1000000;
+
+/**
+ * Component for managing partner logo images in the CHT instance.
+ *
+ * Loads the partners document from CouchDB on init and displays the current
+ * partner logos in a list.
+ * Allows administrators to upload new partner logos by providing a name
+ * and selecting an image file.
+ *
+ * Part of the Images module.
+ */
+@Component({
+  selector: 'images-partners',
+  imports: [TranslatePipe, FormsModule],
+  templateUrl: './images-partners.component.html',
+  styleUrl: './images-partners.component.less'
+})
+export class ImagesPartnersComponent implements OnInit {
+
+  /** Reference to the logo file input element for reading the selected file and resetting after submit */
+  @ViewChild('logoFile') logoFileRef!: ElementRef<HTMLInputElement>;
+  
+  /** Partners document loaded from CouchDB, used to resolve image previews and for submit operations */
+  partnersDoc: PartnersDoc | null = null;
+
+  /** Controls visibility of the loader while the partners document is being fetched */
+  loadingPageStatus = false;
+
+  /** List of partner names fetched from the partners document for template iteration */
+  partners: string[] = [];
+
+  /** Tracks the state of the submit operation for loading and error feedback */
+  responseStatus: ResponseStatus = {};
+
+  /** Model for the name input field of the upload form */
+  name = '';
+
+  constructor(
+    private translate: TranslateService,
+    private partnersService: PartnersService
+  ) {}
+  
+  /**
+   * Fetches the partners document from CouchDB on init and builds
+   * the list of partner names for display in the partners list.
+   */
+  async ngOnInit(): Promise<void> {
+    this.loadingPageStatus = true;
+    try {
+      await this.reloadPartners();
+    } catch (error) {
+      console.error('Error fetching partners document', error);
+    } finally {
+      this.loadingPageStatus = false;
+    }
+  }
+
+  /**
+   * Reloads the partners document from CouchDB without triggering the full page loader.
+   * Called after a successful submit to reflect the newly added partner in the list.
+   */
+  private async reloadPartners(): Promise<void> {
+    this.partnersDoc = await this.partnersService.getPartners();
+    this.partners = Object.keys(this.partnersDoc.resources);
+  }
+
+  /**
+   * Resolves a partner name to its data URI using the partners document.
+   * Returns null if the partners document has not loaded yet or if the image
+   * does not exist in the document.
+   *
+   * @param {string} key - the partner name (e.g. 'apple')
+   * @returns {string | null}
+   */
+  getImageContent(key: string): string | null {
+    if (!this.partnersDoc) {
+      return null;
+    }
+    return this.partnersService.getImageContent(key, this.partnersDoc);
+  }
+
+  //TODO
+  async submit(): Promise<void> {}
+
+
+
+}

--- a/admin-tool/src/ts/modules/images/images-partners/images-partners.component.ts
+++ b/admin-tool/src/ts/modules/images/images-partners/images-partners.component.ts
@@ -5,6 +5,7 @@ import { PartnersService } from '@admin-tool-services/partners.service';
 import { PartnersDoc } from '@admin-tool-modules/images/images-interfaces';
 import { ResponseStatus } from '@admin-tool-modules/global-modules-interfaces';
 
+/** Maximum allowed file size for partner logos in bytes (1MB) */
 const MAX_PARTNERS_FILE_SIZE = 1000000;
 
 /**
@@ -86,10 +87,67 @@ export class ImagesPartnersComponent implements OnInit {
     }
     return this.partnersService.getImageContent(key, this.partnersDoc);
   }
+  /**
+   * Validates the upload form fields before submitting.
+   * Checks in order: name provided, file selected, file size under 1MB.
+   * Sets responseStatus to error with the appropriate message on the first failing validation.
+   *
+   * @param {File | undefined} file - the file selected from the file input
+   * @returns {boolean} true if all validations pass, false otherwise
+   */
+  private validateUpload(file: File | undefined): boolean {
+    if (!this.name) {
+      this.responseStatus = {
+        state: 'error',
+        msg: this.translate.instant('field is required', {
+          field: this.translate.instant('partner.name.field')
+        })
+      };
+      return false;
+    }
+    if (!file) {
+      this.responseStatus = {
+        state: 'error',
+        msg: this.translate.instant('field is required', {
+          field: this.translate.instant('partner.logo.field')
+        })
+      };
+      return false;
+    }
+    if (file.size > MAX_PARTNERS_FILE_SIZE) {
+      this.responseStatus = {
+        state: 'error',
+        msg: `File must be less than ${MAX_PARTNERS_FILE_SIZE / 1000000}MB`
+      };
+      return false;
+    }
+    return true;
+  }
 
-  //TODO
-  async submit(): Promise<void> {}
+  /**
+   * Saves a new partner logo to CouchDB.
+   * Validates the name and file before proceeding.
+   * Resets the file input and name after a successful save.
+   * Reloads the partners list to reflect the newly added logo.
+   * Sets responseStatus to error if the save fails.
+   */
+  async submit(): Promise<void> {
+    const file = this.logoFileRef.nativeElement.files?.[0];
+    
+    if (!this.validateUpload(file)) {
+      return;
+    }
 
-
-
+    this.responseStatus = { state: 'loading'};
+    try {
+      await this.partnersService.uploadPartner(this.name, file!);
+      this.logoFileRef.nativeElement.value = '';
+      this.name = '';
+      await this.reloadPartners();
+      this.responseStatus = {};
+    } catch (error) {
+      console.error('Error uploading partner logo', error);
+      this.responseStatus = { state: 'error', msg: 'Error saving settings' };
+    }
+  }
 }

--- a/admin-tool/src/ts/modules/images/images.routes.ts
+++ b/admin-tool/src/ts/modules/images/images.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { ImagesHeaderComponent } from './images-header/images-header.component';
 import { ImagesIconsComponent } from './images-icons/images-icons.component';
 import { ImagesBrandingComponent } from './images-branding/images-branding.component';
+import { ImagesPartnersComponent } from './images-partners/images-partners.component';
 
 /**
  * Routes for the Images module.
@@ -28,6 +29,10 @@ export const routes: Routes = [
       {
         path: 'branding',
         component: ImagesBrandingComponent,
+      },
+      {
+        path: 'partners',
+        component: ImagesPartnersComponent,
       },
     ],
   },

--- a/admin-tool/src/ts/services/branding.service.ts
+++ b/admin-tool/src/ts/services/branding.service.ts
@@ -92,13 +92,12 @@ export class BrandingService {
    * All changes are saved in a single put operation.
    *
    * @param {string} title - the new application title
-   * @param {BrandingDoc} doc - the current branding document
    * @param {File} [logo] - optional new logo file
    * @param {File} [favicon] - optional new favicon file
    * @param {File} [icon] - optional new icon file
    * @returns {Promise<void>}
    */
-  async updateBranding(title: string, doc: BrandingDoc, logo?: File, favicon?: File, icon?: File): Promise<void> {
+  async updateBranding(title: string, logo?: File, favicon?: File, icon?: File): Promise<void> {
     const freshDoc = await this.getBranding();
     freshDoc.title = title;
 

--- a/admin-tool/src/ts/services/partners.service.ts
+++ b/admin-tool/src/ts/services/partners.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { DbService } from '@admin-tool-services/db.service';
+import { BrandingAttachment, PartnersDoc } from '@admin-tool-modules/images/images-interfaces';
+
+/**
+ * Service responsible for loading and managing partner logo documents from CouchDB.
+ * Partner logos are stored as attachments in the 'partners' document.
+ * The resources map links partner names to their attachment filenames.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class PartnersService {
+
+  constructor(private db: DbService) {}
+
+  /**
+   * Fetches the partners document from CouchDB including all attachment data.
+   * If the document does not exist, returns an empty document instead of throwing.
+   * attachments: true is required to retrieve the base64 content of each image.
+   *
+   * @returns {Promise<PartnersDoc>}
+   */
+  async getPartners(): Promise<PartnersDoc> {
+    const emptyDoc: PartnersDoc = {
+      _id: 'partners',
+      resources: {},
+      _attachments: {},
+    };
+    const doc = await this.db.get().get('partners', { attachments: true })
+      .catch(err => {
+        if (err.status === 404) {
+          return emptyDoc;
+        }
+        throw err;
+      });
+    return doc;
+  }
+  /**
+   * Resolves a partner name to its data URI using the partners document.
+   * Returns null if the key does not exist in the resources map, if the attachment
+   * has no data, or if the data is not a base64 string.
+   *
+   * @param {string} key - the partner name as stored in the resources map (e.g. 'apple')
+   * @param {PartnersDoc} doc - the partners document fetched with attachments: true
+   * @returns {string | null} the data URI string or null if the image cannot be resolved
+   */
+  getImageContent(key: string, doc: PartnersDoc): string | null {
+    const attachmentName = doc.resources[key];
+    if (!attachmentName) {
+      return null;
+    }
+
+    const attachment: BrandingAttachment = doc._attachments[attachmentName];
+    if (!attachment?.data || typeof attachment.data !== 'string') {
+      return null;
+    }
+
+    const content = `data:${attachment.content_type};base64,${attachment.data}`;
+    return content;
+  }
+}

--- a/admin-tool/src/ts/services/partners.service.ts
+++ b/admin-tool/src/ts/services/partners.service.ts
@@ -55,8 +55,28 @@ export class PartnersService {
     if (!attachment?.data || typeof attachment.data !== 'string') {
       return null;
     }
-
+    
     const content = `data:${attachment.content_type};base64,${attachment.data}`;
     return content;
+  }
+
+  /**
+   * Uploads a new partner logo to the partners document in CouchDB.
+   * Fetches the current document with attachments to obtain the latest _rev,
+   * adds the file directly to the document attachments, updates the resources map,
+   * and saves everything in a single put operation.
+   *
+   * @param {string} name - the logical partner name to register in the resources map
+   * @param {File} file - the logo file to attach
+   * @returns {Promise<void>}
+   */
+  async uploadPartner(name: string, file: File): Promise<void> {
+    const doc = await this.getPartners();
+    doc._attachments[file.name] = {
+      content_type: file.type,
+      data: file as any,
+    };
+    doc.resources[name] = file.name;
+    await this.db.get().put(doc);
   }
 }

--- a/admin-tool/src/ts/services/partners.service.ts
+++ b/admin-tool/src/ts/services/partners.service.ts
@@ -36,6 +36,7 @@ export class PartnersService {
       });
     return doc;
   }
+  
   /**
    * Resolves a partner name to its data URI using the partners document.
    * Returns null if the key does not exist in the resources map, if the attachment
@@ -55,7 +56,7 @@ export class PartnersService {
     if (!attachment?.data || typeof attachment.data !== 'string') {
       return null;
     }
-    
+
     const content = `data:${attachment.content_type};base64,${attachment.data}`;
     return content;
   }

--- a/admin-tool/tests/karma/ts/modules/images/images-branding.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/images/images-branding.component.spec.ts
@@ -192,7 +192,6 @@ describe('ImagesBrandingComponent', () => {
       await component.submit();
       expect(brandingService.updateBranding.calledWith(
         'Community Health Toolkit',
-        mockBrandingDoc,
         logo,
         undefined,
         undefined

--- a/admin-tool/tests/karma/ts/modules/images/images-partners.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/images/images-partners.component.spec.ts
@@ -34,6 +34,7 @@ describe('ImagesPartnersComponent', () => {
     partnersService = {
       getPartners: sinon.stub().resolves(mockPartnersDoc),
       getImageContent: sinon.stub().returns(null),
+      uploadPartner: sinon.stub().resolves(),
     };
 
     return TestBed.configureTestingModule({
@@ -127,6 +128,143 @@ describe('ImagesPartnersComponent', () => {
       partnersService.getImageContent.returns(dataUri);
       const result = component.getImageContent('apple');
       expect(result).to.equal(dataUri);
+    });
+  });
+  describe('submit', () => {
+    beforeEach(async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+    });
+
+    const setFiles = (file: File | null) => {
+      Object.defineProperty(component.logoFileRef.nativeElement, 'files', {
+        value: file ? [file] : [],
+        configurable: true,
+      });
+    };
+
+    it('should set error if name is empty', async () => {
+      component.name = '';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+    });
+
+    it('should set error message if name is empty', async () => {
+      component.name = '';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(component.responseStatus.msg).to.equal('field is required');
+    });
+
+    it('should set error if no file selected', async () => {
+      component.name = 'apple';
+      setFiles(null);
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+    });
+
+    it('should set error message if no file selected', async () => {
+      component.name = 'apple';
+      setFiles(null);
+      await component.submit();
+      expect(component.responseStatus.msg).to.equal('field is required');
+    });
+
+    it('should set error if file is larger than 1MB', async () => {
+      component.name = 'apple';
+      const file = new File([new ArrayBuffer(1000001)], 'apple.png', { type: 'image/png' });
+      setFiles(file);
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+    });
+
+    it('should set error message if file is larger than 1MB', async () => {
+      component.name = 'apple';
+      const file = new File([new ArrayBuffer(1000001)], 'apple.png', { type: 'image/png' });
+      setFiles(file);
+      await component.submit();
+      expect(component.responseStatus.msg).to.equal('File must be less than 1MB');
+    });
+
+    it('should not call uploadPartner if name is empty', async () => {
+      component.name = '';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(partnersService.uploadPartner.called).to.be.false;
+    });
+
+    it('should not call uploadPartner if no file selected', async () => {
+      component.name = 'apple';
+      setFiles(null);
+      await component.submit();
+      expect(partnersService.uploadPartner.called).to.be.false;
+    });
+
+    it('should set responseStatus to loading during submit', async () => {
+      component.name = 'apple';
+      const file = new File([''], 'apple.png', { type: 'image/png' });
+      setFiles(file);
+      partnersService.uploadPartner.callsFake(() => {
+        expect(component.responseStatus.state).to.equal('loading');
+        return Promise.resolve();
+      });
+      await component.submit();
+    });
+
+    it('should call uploadPartner with correct arguments', async () => {
+      component.name = 'apple';
+      const file = new File([''], 'apple.png', { type: 'image/png' });
+      setFiles(file);
+      await component.submit();
+      expect(partnersService.uploadPartner.calledWith('apple', file)).to.be.true;
+    });
+
+    it('should reset file input after success', async () => {
+      component.name = 'apple';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(component.logoFileRef.nativeElement.value).to.equal('');
+    });
+
+    it('should reset name after success', async () => {
+      component.name = 'apple';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(component.name).to.equal('');
+    });
+
+    it('should call getPartners more than once after success', async () => {
+      component.name = 'apple';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(partnersService.getPartners.callCount).to.be.greaterThan(1);
+    });
+
+    it('should clear responseStatus after success', async () => {
+      component.name = 'apple';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(component.responseStatus).to.deep.equal({});
+    });
+
+    it('should set error responseStatus if uploadPartner fails', async () => {
+      partnersService.uploadPartner.rejects(new Error('error'));
+      sinon.stub(console, 'error');
+      component.name = 'apple';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(component.responseStatus.state).to.equal('error');
+      expect(component.responseStatus.msg).to.equal('Error saving settings');
+    });
+
+    it('should call console.error if uploadPartner fails', async () => {
+      partnersService.uploadPartner.rejects(new Error('error'));
+      const consoleStub = sinon.stub(console, 'error');
+      component.name = 'apple';
+      setFiles(new File([''], 'apple.png', { type: 'image/png' }));
+      await component.submit();
+      expect(consoleStub.calledWith('Error uploading partner logo', sinon.match.any)).to.be.true;
     });
   });
   describe('DOM', () => {

--- a/admin-tool/tests/karma/ts/modules/images/images-partners.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/images/images-partners.component.spec.ts
@@ -1,0 +1,218 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { ImagesPartnersComponent } from '@admin-tool-modules/images/images-partners/images-partners.component';
+import { PartnersService } from '@admin-tool-services/partners.service';
+import { PartnersDoc } from '@admin-tool-modules/images/images-interfaces';
+
+describe('ImagesPartnersComponent', () => {
+  let component: ImagesPartnersComponent;
+  let fixture: ComponentFixture<ImagesPartnersComponent>;
+  let partnersService;
+
+  const mockPartnersDoc: PartnersDoc = {
+    _id: 'partners',
+    _rev: '7-abc123',
+    resources: {
+      apple: 'logotipo-grande-de-apple.png',
+      adidas: 'adidas.png',
+    },
+    _attachments: {
+      'logotipo-grande-de-apple.png': {
+        content_type: 'image/png',
+        data: btoa('apple-content'),
+      },
+      'adidas.png': {
+        content_type: 'image/png',
+        data: btoa('adidas-content'),
+      },
+    },
+  };
+
+  beforeEach(waitForAsync(() => {
+    partnersService = {
+      getPartners: sinon.stub().resolves(mockPartnersDoc),
+      getImageContent: sinon.stub().returns(null),
+    };
+
+    return TestBed.configureTestingModule({
+      imports: [ImagesPartnersComponent, TranslateModule.forRoot()],
+      providers: [{ provide: PartnersService, useValue: partnersService }],
+    })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(ImagesPartnersComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+  }));
+
+  afterEach(() => sinon.restore());
+
+  describe('initial state', () => {
+    it('should create', () => {
+      expect(component).to.exist;
+    });
+
+    it('should start with loadingPageStatus false', () => {
+      expect(component.loadingPageStatus).to.be.false;
+    });
+
+    it('should start with empty responseStatus', () => {
+      expect(component.responseStatus).to.deep.equal({});
+    });
+
+    it('should start with empty name', () => {
+      expect(component.name).to.equal('');
+    });
+  });
+  describe('ngOnInit', () => {
+    it('should call getPartners on init', () => {
+      expect(partnersService.getPartners.calledOnce).to.be.true;
+    });
+
+    it('should set partnersDoc after init', async () => {
+      await fixture.whenStable();
+      expect(component.partnersDoc).to.deep.equal(mockPartnersDoc);
+    });
+
+    it('should set partners after init', async () => {
+      await fixture.whenStable();
+      expect(component.partners).to.deep.equal(['apple', 'adidas']);
+    });
+
+    it('should set loadingPageStatus to false after init', async () => {
+      await fixture.whenStable();
+      expect(component.loadingPageStatus).to.be.false;
+    });
+
+    it('should set loadingPageStatus to false even if getPartners fails', async () => {
+      sinon.stub(console, 'error');
+      partnersService.getPartners.rejects(new Error('error'));
+      await component.ngOnInit();
+      expect(component.loadingPageStatus).to.be.false;
+    });
+
+    it('should handle error if getPartners fails', async () => {
+      const consoleStub = sinon.stub(console, 'error');
+      partnersService.getPartners.rejects(new Error('error'));
+      await component.ngOnInit();
+      expect(consoleStub.calledWith('Error fetching partners document', sinon.match.any)).to.be.true;
+    });
+  });
+  describe('getImageContent', () => {
+    it('should return null if partnersDoc is null', () => {
+      component.partnersDoc = null;
+      const result = component.getImageContent('apple');
+      expect(result).to.be.null;
+    });
+
+    it('should call getImageContent from service with correct parameters', async () => {
+      await fixture.whenStable();
+      component.getImageContent('apple');
+      expect(partnersService.getImageContent.calledWith('apple', mockPartnersDoc)).to.be.true;
+    });
+
+    it('should return null when service returns null', async () => {
+      await fixture.whenStable();
+      partnersService.getImageContent.returns(null);
+      const result = component.getImageContent('apple');
+      expect(result).to.be.null;
+    });
+
+    it('should return string when service returns content', async () => {
+      await fixture.whenStable();
+      const dataUri = `data:image/png;base64,${btoa('apple-content')}`;
+      partnersService.getImageContent.returns(dataUri);
+      const result = component.getImageContent('apple');
+      expect(result).to.equal(dataUri);
+    });
+  });
+  describe('DOM', () => {
+    it('should show loader when loadingPageStatus is true', () => {
+      component.loadingPageStatus = true;
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.loader')).to.exist;
+    });
+
+    it('should not show loader when loadingPageStatus is false', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.loader')).to.not.exist;
+    });
+
+    it('should render name input', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('#name')).to.exist;
+    });
+
+    it('should render choose file button', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('button.btn-default')).to.exist;
+    });
+
+    it('should render submit button', async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('button.btn-primary')).to.exist;
+    });
+
+    it('should disable submit button when responseStatus is loading', async () => {
+      await fixture.whenStable();
+      component.responseStatus = { state: 'loading' };
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      const button = compiled.querySelector('button.btn-primary') as HTMLButtonElement;
+      expect(button.disabled).to.be.true;
+    });
+
+    it('should show inline loader when responseStatus is loading', async () => {
+      await fixture.whenStable();
+      component.responseStatus = { state: 'loading' };
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.loader.inline')).to.exist;
+    });
+
+    it('should show error message when responseStatus is error', async () => {
+      await fixture.whenStable();
+      component.responseStatus = { state: 'error', msg: 'Error saving settings' };
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.error')).to.exist;
+    });
+
+    it('should not show partners section when partners is empty', async () => {
+      await fixture.whenStable();
+      component.partners = [];
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.list-inline')).to.not.exist;
+    });
+
+    it('should render partners list when partners exist', async () => {
+      await fixture.whenStable();
+      partnersService.getImageContent.returns(`data:image/png;base64,${btoa('apple-content')}`);
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('.list-inline')).to.exist;
+    });
+
+    it('should render one li per partner', async () => {
+      await fixture.whenStable();
+      partnersService.getImageContent.returns(`data:image/png;base64,${btoa('apple-content')}`);
+      fixture.detectChanges();
+      const compiled = fixture.nativeElement as HTMLElement;
+      const items = compiled.querySelectorAll('.list-inline li');
+      expect(items.length).to.equal(2);
+    });
+  });
+});

--- a/admin-tool/tests/karma/ts/services/branding.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/branding.service.spec.ts
@@ -132,24 +132,24 @@ describe('BrandingService', () => {
   });
   describe('updateBranding', () => {
     it('should call getBranding to fetch the current doc', async () => {
-      await service.updateBranding('New Title', mockBrandingDoc);
+      await service.updateBranding('New Title');
       expect(dbService.get().get.calledWith('branding', { attachments: true })).to.be.true;
     });
 
     it('should update the title in the doc', async () => {
-      await service.updateBranding('New Title', mockBrandingDoc);
+      await service.updateBranding('New Title');
       const doc = dbService.get().put.args[0][0];
       expect(doc.title).to.equal('New Title');
     });
 
     it('should call db.put with the updated doc', async () => {
-      await service.updateBranding('New Title', mockBrandingDoc);
+      await service.updateBranding('New Title');
       expect(dbService.get().put.calledOnce).to.be.true;
     });
 
     it('should add logo attachment when logo file is provided', async () => {
       const file = new File([''], 'new-logo.png', { type: 'image/png' });
-      await service.updateBranding('New Title', mockBrandingDoc, file);
+      await service.updateBranding('New Title', file);
       const doc = dbService.get().put.args[0][0];
       expect(doc._attachments['new-logo.png'].content_type).to.equal('image/png');
       expect(doc.resources['logo']).to.equal('new-logo.png');
@@ -157,7 +157,7 @@ describe('BrandingService', () => {
 
     it('should add favicon attachment when favicon file is provided', async () => {
       const file = new File([''], 'new-favicon.ico', { type: 'image/x-icon' });
-      await service.updateBranding('New Title', mockBrandingDoc, undefined, file);
+      await service.updateBranding('New Title', undefined, file);
       const doc = dbService.get().put.args[0][0];
       expect(doc._attachments['new-favicon.ico'].content_type).to.equal('image/x-icon');
       expect(doc.resources['favicon']).to.equal('new-favicon.ico');
@@ -165,7 +165,7 @@ describe('BrandingService', () => {
 
     it('should add icon attachment when icon file is provided', async () => {
       const file = new File([''], 'new-icon.png', { type: 'image/png' });
-      await service.updateBranding('New Title', mockBrandingDoc, undefined, undefined, file);
+      await service.updateBranding('New Title', undefined, undefined, file);
       const doc = dbService.get().put.args[0][0];
       expect(doc._attachments['new-icon.png'].content_type).to.equal('image/png');
       expect(doc.resources['icon']).to.equal('new-icon.png');
@@ -173,13 +173,13 @@ describe('BrandingService', () => {
 
     it('should remove obsolete attachments after update', async () => {
       const file = new File([''], 'new-logo.png', { type: 'image/png' });
-      await service.updateBranding('New Title', mockBrandingDoc, file);
+      await service.updateBranding('New Title', file);
       const doc = dbService.get().put.args[0][0];
       expect(doc._attachments['cht-logo.png']).to.be.undefined;
     });
 
     it('should keep existing attachments that are still referenced', async () => {
-      await service.updateBranding('New Title', mockBrandingDoc);
+      await service.updateBranding('New Title');
       const doc = dbService.get().put.args[0][0];
       expect(doc._attachments['cht-logo.png']).to.exist;
       expect(doc._attachments['favicon.ico']).to.exist;
@@ -188,7 +188,7 @@ describe('BrandingService', () => {
     it('should propagate error if getBranding fails', async () => {
       dbService.get().get.rejects(new Error('error'));
       try {
-        await service.updateBranding('New Title', mockBrandingDoc);
+        await service.updateBranding('New Title');
         expect.fail('should have thrown');
       } catch (error: any) {
         expect(error.message).to.equal('error');
@@ -198,7 +198,7 @@ describe('BrandingService', () => {
     it('should propagate error if db.put fails', async () => {
       dbService.get().put.rejects(new Error('put error'));
       try {
-        await service.updateBranding('New Title', mockBrandingDoc);
+        await service.updateBranding('New Title');
         expect.fail('should have thrown');
       } catch (error: any) {
         expect(error.message).to.equal('put error');

--- a/admin-tool/tests/karma/ts/services/partners.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/partners.service.spec.ts
@@ -125,4 +125,50 @@ describe('PartnersService', () => {
       expect(result).to.be.null;
     });
   });
+  describe('uploadPartner', () => {
+    it('should call getPartners to fetch the current doc', async () => {
+      await service.uploadPartner('apple', new File([''], 'apple.png', { type: 'image/png' }));
+      expect(dbService.get().get.calledWith('partners', { attachments: true })).to.be.true;
+    });
+
+    it('should add the file as an inline attachment', async () => {
+      const file = new File([''], 'apple.png', { type: 'image/png' });
+      await service.uploadPartner('apple', file);
+      const doc = dbService.get().put.args[0][0];
+      expect(doc._attachments['apple.png'].content_type).to.equal('image/png');
+      expect(doc._attachments['apple.png'].data).to.equal(file);
+    });
+
+    it('should add the name to the resources map', async () => {
+      const file = new File([''], 'apple.png', { type: 'image/png' });
+      await service.uploadPartner('apple', file);
+      const doc = dbService.get().put.args[0][0];
+      expect(doc.resources['apple']).to.equal('apple.png');
+    });
+
+    it('should call db.put with the updated doc', async () => {
+      await service.uploadPartner('apple', new File([''], 'apple.png', { type: 'image/png' }));
+      expect(dbService.get().put.calledOnce).to.be.true;
+    });
+
+    it('should propagate error if getPartners fails', async () => {
+      dbService.get().get.rejects(new Error('error'));
+      try {
+        await service.uploadPartner('apple', new File([''], 'apple.png', { type: 'image/png' }));
+        expect.fail('should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.equal('error');
+      }
+    });
+
+    it('should propagate error if db.put fails', async () => {
+      dbService.get().put.rejects(new Error('put error'));
+      try {
+        await service.uploadPartner('apple', new File([''], 'apple.png', { type: 'image/png' }));
+        expect.fail('should have thrown');
+      } catch (error: any) {
+        expect(error.message).to.equal('put error');
+      }
+    });
+  });
 });

--- a/admin-tool/tests/karma/ts/services/partners.service.spec.ts
+++ b/admin-tool/tests/karma/ts/services/partners.service.spec.ts
@@ -1,0 +1,128 @@
+import { TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { PartnersService } from '@admin-tool-services/partners.service';
+import { DbService } from '@admin-tool-services/db.service';
+import { PartnersDoc } from '@admin-tool-modules/images/images-interfaces';
+
+describe('PartnersService', () => {
+  let service: PartnersService;
+  let dbService;
+
+  const mockPartnersDoc: PartnersDoc = {
+    _id: 'partners',
+    _rev: '7-abc123',
+    resources: {
+      apple: 'logotipo-grande-de-apple.png',
+      adidas: 'adidas.png',
+    },
+    _attachments: {
+      'logotipo-grande-de-apple.png': {
+        content_type: 'image/png',
+        data: btoa('apple-content'),
+      },
+      'adidas.png': {
+        content_type: 'image/png',
+        data: btoa('adidas-content'),
+      },
+    },
+  };
+
+  beforeEach(() => {
+    dbService = {
+      get: sinon.stub().returns({
+        get: sinon.stub().callsFake(() => Promise.resolve(JSON.parse(JSON.stringify(mockPartnersDoc)))),
+        put: sinon.stub().resolves(),
+      }),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: DbService, useValue: dbService }],
+    });
+
+    service = TestBed.inject(PartnersService);
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('getPartners', () => {
+    it('should call db.get with correct document id and attachments option', async () => {
+      await service.getPartners();
+      expect(dbService.get().get.calledWith('partners', { attachments: true })).to.be.true;
+    });
+
+    it('should return the partners doc', async () => {
+      const result = await service.getPartners();
+      expect(result._id).to.equal('partners');
+    });
+
+    it('should return the resources map', async () => {
+      const result = await service.getPartners();
+      expect(result.resources).to.deep.equal(mockPartnersDoc.resources);
+    });
+
+    it('should return empty doc if db.get returns 404', async () => {
+      dbService.get().get.rejects({ status: 404 });
+      const result = await service.getPartners();
+      expect(result._id).to.equal('partners');
+      expect(result.resources).to.deep.equal({});
+      expect(result._attachments).to.deep.equal({});
+    });
+
+    it('should propagate error if db.get fails with non-404', async () => {
+      dbService.get().get.rejects({ status: 500 });
+      try {
+        await service.getPartners();
+        expect.fail('should have thrown');
+      } catch (error: any) {
+        expect(error.status).to.equal(500);
+      }
+    });
+  });
+  describe('getImageContent', () => {
+    it('should return data URI for png image', () => {
+      const result = service.getImageContent('apple', mockPartnersDoc);
+      expect(result).to.equal(`data:image/png;base64,${btoa('apple-content')}`);
+    });
+
+    it('should return null if key does not exist in resources', () => {
+      const result = service.getImageContent('unknown', mockPartnersDoc);
+      expect(result).to.be.null;
+    });
+
+    it('should return null if attachment has no data', () => {
+      const docWithoutData: PartnersDoc = {
+        ...mockPartnersDoc,
+        _attachments: {
+          'logotipo-grande-de-apple.png': { content_type: 'image/png' }
+        }
+      };
+      const result = service.getImageContent('apple', docWithoutData);
+      expect(result).to.be.null;
+    });
+
+    it('should return null if attachment data is a File', () => {
+      const docWithFile: PartnersDoc = {
+        ...mockPartnersDoc,
+        _attachments: {
+          'logotipo-grande-de-apple.png': {
+            content_type: 'image/png',
+            data: new File([''], 'apple.png', { type: 'image/png' }) as any
+          }
+        }
+      };
+      const result = service.getImageContent('apple', docWithFile);
+      expect(result).to.be.null;
+    });
+
+    it('should return null if resources map is empty', () => {
+      const emptyDoc: PartnersDoc = {
+        ...mockPartnersDoc,
+        resources: {},
+        _attachments: {}
+      };
+      const result = service.getImageContent('apple', emptyDoc);
+      expect(result).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

## Description

Implements the Partners tab in the Images section of the admin tool. Administrators can view all currently configured partner logos and upload new ones by providing a partner name and selecting an image file. The form validates the name as required, the file as required, and enforces a 1MB size limit before saving to CouchDB in a single operation.

**Changes include:**
- Added PartnersDoc interface to images-interfaces.ts to represent the partners CouchDB document structure
- Added PartnersService with getPartners to fetch the partners document with attachments returning an empty document if it does not exist, getImageContent to resolve partner names to data URIs, and uploadPartner to add a new logo as an inline attachment and update the resources map in a single put operation
- Added ImagesPartnersComponent with ngOnInit to load the partners document and build the list of partner names, getImageContent as a wrapper to resolve image previews from the template, validateUpload to validate the name field, file selection and file size in order, reloadPartners to refresh the document after a successful submit without triggering the page loader, and submit to orchestrate the full upload flow with loading state, input reset on success and error feedback on failure
- Added the partners route to images.routes.ts
- Added unit tests for PartnersService and ImagesPartnersComponent

<img width="1062" height="284" alt="Screenshot 2026-05-11 at 3 29 44 PM" src="https://github.com/user-attachments/assets/11a6fbf5-6820-4b0c-9d14-f5481ff1a1be" />
<img width="1174" height="794" alt="Screenshot 2026-05-11 at 3 56 54 PM" src="https://github.com/user-attachments/assets/446f1e9f-4b87-4a3c-9150-c93bb59ac6af" />
<img width="1174" height="794" alt="Screenshot 2026-05-11 at 3 56 57 PM" src="https://github.com/user-attachments/assets/0a80f7a8-a6ee-469b-81b8-b14a354d665f" />
<img width="1174" height="794" alt="Screenshot 2026-05-11 at 3 57 11 PM" src="https://github.com/user-attachments/assets/c7d9e552-6090-4b15-abdb-f321b633cfef" />
<img width="1174" height="794" alt="Screenshot 2026-05-11 at 3 57 24 PM" src="https://github.com/user-attachments/assets/d0fa11fe-8041-4b6c-b84e-0414ee734a89" />
<img width="1174" height="794" alt="Screenshot 2026-05-11 at 3 58 19 PM" src="https://github.com/user-attachments/assets/57b80247-fcd6-456f-b244-2d2a0be142e0" />

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

