### PR TITLE
feat(#32): add SMS forms module

### DIFF
--- a/admin-tool/src/ts/modules/sms/sms-forms/sms-forms-interfaces.ts
+++ b/admin-tool/src/ts/modules/sms/sms-forms/sms-forms-interfaces.ts
@@ -1,0 +1,20 @@
+export interface SmsForm {
+  meta: {
+    code: string;
+    icon?: string;
+    translation_key?: string;
+    label?: Record<string, string>;
+  };
+  [key: string]: unknown;
+}
+
+export interface SmsFormsDownload {
+  name: string;
+  url: string;
+}
+
+export interface SmsFormsStatus {
+  uploading: boolean;
+  error?: boolean;
+  success?: boolean;
+}

--- a/admin-tool/src/ts/modules/sms/sms-forms/sms-forms.component.html
+++ b/admin-tool/src/ts/modules/sms/sms-forms/sms-forms.component.html
@@ -1,0 +1,67 @@
+<div class="sms-configuration-container">
+
+  <form>
+    <p>{{ 'configuration.sms.forms.title' | translate }}</p>
+    <legend>{{ 'upload.sms.forms' | translate }}</legend>
+
+    <div class="form-actions">
+      <a class="btn btn-primary" [class.disabled]="status.uploading" (click)="onChooseClick($event)">
+        <i class="fa fa-arrow-up"></i>
+        <span>{{ 'upload' | translate }}</span>
+      </a>
+      @if (status.error) {
+        <div class="error">{{ 'Upload failed' | translate }}</div>
+      }
+      @if (status.uploading) {
+        <div class="loader"></div>
+      }
+      <span class="help-block">{{ 'upload.json.forms.help' | translate }}</span>
+      <div class="hide">
+        <input #fileInput type="file" accept="application/json" />
+      </div>
+    </div>
+  </form>
+
+  <div class="section">
+    <fieldset>
+      <legend>{{ 'Installed Forms' | translate }}</legend>
+      <a
+        class="btn btn-primary"
+        [attr.download]="download.name"
+        [href]="download.url"
+      >
+        <i class="fa fa-arrow-down"></i>
+        <span>{{ 'Download' | translate }}</span>
+      </a>
+
+      <div class="row selection-heading">
+        <div class="col-sm-2">{{ 'icon' | translate }}</div>
+        <div class="col-sm-5">{{ 'unique.id' | translate }}</div>
+        <div class="col-sm-5">{{ 'title' | translate }}</div>
+      </div>
+
+      <div>
+        <ul>
+          @for (form of formsList; track form.meta.code) {
+            <li class="row">
+              <div class="col-sm-2">
+                @if (getIconContent(form.meta.icon).isSvg) {
+                  <span [innerHTML]="getIconContent(form.meta.icon).content"></span>
+                } @else if (getIconContent(form.meta.icon).content) {
+                  <img [src]="getIconContent(form.meta.icon).content" />
+                }
+              </div>
+              <div class="col-sm-5">{{ form.meta.code }}</div>
+              @if (form.meta.translation_key) {
+                <div class="col-sm-5">{{ form.meta.translation_key | translate }}</div>
+              } @else {
+                <div class="col-sm-5">{{ form.meta.label }}</div>
+              }
+            </li>
+          }
+        </ul>
+      </div>
+    </fieldset>
+  </div>
+
+</div>

--- a/admin-tool/src/ts/modules/sms/sms-forms/sms-forms.component.less
+++ b/admin-tool/src/ts/modules/sms/sms-forms/sms-forms.component.less
@@ -1,0 +1,19 @@
+@import (reference) "../../../../css/variables.less";
+
+.selection-heading {
+  font-weight: bold;
+  font-size: 1rem;
+  padding: 0.5rem 0;
+  border-bottom: 0.0625rem solid @nav-active-border;
+  margin-bottom: 0.5rem;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+
+  li.row {
+    padding: 0.5rem 0;
+    border-bottom: 0.0625rem solid @nav-active-border;
+  }
+}

--- a/admin-tool/src/ts/modules/sms/sms-forms/sms-forms.component.ts
+++ b/admin-tool/src/ts/modules/sms/sms-forms/sms-forms.component.ts
@@ -1,0 +1,193 @@
+import { Component, AfterViewInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+import { SettingsService } from '@admin-tool-services/settings.service';
+import { ResourcesService } from '@admin-tool-services/resources.service';
+import { ResourcesDoc } from '@admin-tool-modules/resources-interfaces';
+
+import { SmsForm, SmsFormsDownload, SmsFormsStatus } from './sms-forms-interfaces';
+
+const moment = require('moment');
+
+@Component({
+  selector: 'sms-forms',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  templateUrl: './sms-forms.component.html',
+  styleUrl: './sms-forms.component.less',
+})
+export class SmsFormsComponent implements AfterViewInit, OnDestroy {
+
+  @ViewChild('fileInput') fileInputRef!: ElementRef<HTMLInputElement>;
+
+  /** Map of installed SMS forms keyed by form code */
+  forms: Record<string, SmsForm> = {};
+
+  /** Download link data for the installed forms JSON */
+  download: SmsFormsDownload = { name: '', url: '' };
+
+  /** Tracks the state of the upload operation */
+  status: SmsFormsStatus = { uploading: false };
+
+  /** Resources document used to resolve icon content for display */
+  resourcesDoc: ResourcesDoc | null = null;
+
+  private changeHandler = (event: Event) => this.upload(event);
+
+  constructor(
+    private readonly settingsService: SettingsService,
+    private readonly resourcesService: ResourcesService,
+    private readonly sanitizer: DomSanitizer,
+  ) {}
+
+  ngAfterViewInit(): void {
+    this.fileInputRef.nativeElement.addEventListener('change', this.changeHandler);
+    this.loadForms();
+    this.loadResources();
+  }
+
+  ngOnDestroy(): void {
+    this.fileInputRef?.nativeElement?.removeEventListener('change', this.changeHandler);
+  }
+
+  /** Returns the installed forms as an array for template iteration */
+  get formsList(): SmsForm[] {
+    return Object.values(this.forms);
+  }
+
+  /**
+   * Triggers the hidden file input click to open the file picker.
+   *
+   * @param {Event} event - the click event from the choose button
+   */
+  onChooseClick(event: Event): void {
+    event.preventDefault();
+    this.fileInputRef.nativeElement.click();
+  }
+
+  /**
+   * Resolves the icon content for a given icon name using the resources document.
+   * Returns empty content if the resources document has not loaded yet
+   * or if the icon name is empty.
+   * Applies bypassSecurityTrustHtml for SVG icons to allow inline rendering.
+   *
+   * @param {string} iconName - the icon name as stored in the resources document
+   * @returns {{ isSvg: boolean; content: string | SafeHtml }}
+   */
+  getIconContent(iconName?: string): { isSvg: boolean; content: string | SafeHtml } {
+    if (!this.resourcesDoc || !iconName) {
+      return { isSvg: false, content: '' };
+    }
+    const result = this.resourcesService.getIconContent(iconName, this.resourcesDoc);
+    if (result.isSvg) {
+      return {
+        isSvg: true,
+        content: this.sanitizer.bypassSecurityTrustHtml(result.content),
+      };
+    }
+    return result;
+  }
+
+  /**
+   * Loads the installed SMS forms from settings and generates the download link.
+   */
+  private loadForms(): void {
+    this.settingsService.get()
+      .then(settings => {
+        this.forms = (settings as any).forms || {};
+        this.download = this.generateDownload(this.forms);
+      })
+      .catch(err => console.error('Error fetching settings', err));
+  }
+
+  /**
+   * Loads the resources document from CouchDB for icon rendering.
+   */
+  private loadResources(): void {
+    this.resourcesService.getResources()
+      .then(doc => this.resourcesDoc = doc)
+      .catch(err => console.error('Error fetching resources', err));
+  }
+
+  /**
+   * Generates the download link for the installed forms as a JSON file.
+   *
+   * @param {Record<string, SmsForm>} forms - the installed forms map
+   * @returns {SmsFormsDownload} the download name and object URL
+   */
+  private generateDownload(forms: Record<string, SmsForm>): SmsFormsDownload {
+    const json = JSON.stringify(Object.values(forms));
+    const blob = new Blob([json], { type: 'application/json' });
+    return {
+      name: 'forms_' + moment().format('YYYY-MM-DD') + '.json',
+      url: URL.createObjectURL(blob),
+    };
+  }
+
+  /**
+   * Handles the file input change event.
+   * Reads the selected JSON file, parses the forms, saves them to settings,
+   * and reloads the forms list on success.
+   *
+   * @param {Event} event - the change event from the file input
+   */
+  private upload(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const files = input.files;
+
+    if (!files || files.length === 0) {
+      this.uploadFinished(new Error('File not found'));
+      return;
+    }
+
+    this.status = { uploading: true, error: false, success: false };
+
+    const file = files[0];
+    const reader = new FileReader();
+
+    reader.addEventListener('loadend', () => {
+      try {
+        const json: SmsForm[] = JSON.parse(reader.result as string);
+        const forms: Record<string, SmsForm> = {};
+
+        json.forEach(form => {
+          if (form.meta?.code) {
+            forms[form.meta.code.toUpperCase()] = form;
+          }
+        });
+
+        this.settingsService.updateSettings({ forms }, true)
+          .then(() => {
+            this.forms = forms;
+            this.download = this.generateDownload(forms);
+            input.value = '';
+            this.uploadFinished();
+          })
+          .catch(err => this.uploadFinished(err));
+      } catch (err) {
+        this.uploadFinished(err as Error);
+      }
+    });
+
+    reader.addEventListener('error', () => this.uploadFinished(reader.error as Error));
+    reader.readAsText(file);
+  }
+
+  /**
+   * Finalises the upload operation, setting the success or error status.
+   *
+   * @param {Error} err - the error if upload failed, undefined on success
+   */
+  private uploadFinished(err?: Error | null): void {
+    if (err) {
+      console.error('Upload failed', err);
+    }
+    this.status = {
+      uploading: false,
+      error: !!err,
+      success: !err,
+    };
+  }
+}

--- a/admin-tool/src/ts/modules/sms/sms.routes.ts
+++ b/admin-tool/src/ts/modules/sms/sms.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { SmsComponent } from './sms.component';
 import { SmsSettingsComponent } from './sms-settings/sms-settings.component';
+import { SmsFormsComponent } from './sms-forms/sms-forms.component';
 import { SmsTestComponent } from './sms-test/sms-test.component';
 
 /**
@@ -9,25 +10,18 @@ import { SmsTestComponent } from './sms-test/sms-test.component';
  * Defaults to the settings tab on load.
  * Child routes:
  *   - /sms/settings - configure SMS settings
+ *   - /sms/forms - manage SMS forms
+ *   - /sms/test - send a test SMS
  */
 export const routes: Routes = [
   {
     path: 'sms',
     component: SmsComponent,
     children: [
-      {
-        path: '',
-        redirectTo: 'settings',
-        pathMatch: 'full',
-      },
-      {
-        path: 'settings',
-        component: SmsSettingsComponent,
-      },
-      {
-        path: 'test',
-        component: SmsTestComponent,
-      },
+      { path: '', redirectTo: 'settings', pathMatch: 'full' },
+      { path: 'settings', component: SmsSettingsComponent },
+      { path: 'forms', component: SmsFormsComponent },
+      { path: 'test', component: SmsTestComponent },
     ],
   },
 ];

--- a/admin-tool/tests/karma/ts/modules/sms/sms-forms.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/sms/sms-forms.component.spec.ts
@@ -1,0 +1,320 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { TranslateModule } from '@ngx-translate/core';
+import { SmsFormsComponent } from '@admin-tool-modules/sms/sms-forms/sms-forms.component';
+import { SettingsService } from '@admin-tool-services/settings.service';
+import { ResourcesService } from '@admin-tool-services/resources.service';
+
+const mockForm = (overrides: any = {}) => ({
+  meta: {
+    code: 'FORM1',
+    icon: 'icon-treatment',
+    translation_key: 'form.title',
+  },
+  ...overrides,
+});
+
+const mockSettings = (forms: any = {}) => ({ forms });
+
+const mockResourcesDoc = () => ({
+  _id: 'resources',
+  resources: { 'icon-treatment': 'icon-treatment.svg' },
+  _attachments: {
+    'icon-treatment.svg': {
+      content_type: 'image/svg+xml',
+      data: btoa('<svg><circle/></svg>'),
+    },
+  },
+});
+
+describe('SmsFormsComponent', () => {
+  let component: SmsFormsComponent;
+  let fixture: ComponentFixture<SmsFormsComponent>;
+  let settingsService: any;
+  let resourcesService: any;
+
+  const stabilize = async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await fixture.whenStable();
+  };
+
+  const mockFile = (content: string, name = 'forms.json'): File => {
+    return new File([content], name, { type: 'application/json' });
+  };
+
+  const triggerFileInput = (file: File) => {
+    const input = fixture.nativeElement.querySelector('input[type="file"]');
+    Object.defineProperty(input, 'files', { value: [file], configurable: true });
+    input.dispatchEvent(new Event('change'));
+  };
+
+  beforeEach(async () => {
+    settingsService = {
+      get: sinon.stub().resolves(mockSettings()),
+      updateSettings: sinon.stub().resolves(),
+    };
+    resourcesService = {
+      getResources: sinon.stub().resolves(mockResourcesDoc()),
+      getIconContent: sinon.stub().returns({ isSvg: false, content: '' }),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [SmsFormsComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: SettingsService, useValue: settingsService },
+        { provide: ResourcesService, useValue: resourcesService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SmsFormsComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => sinon.restore());
+
+  // --- ZERO ---
+  describe('Zero', () => {
+    it('should initialise with empty forms and clean status', () => {
+      expect(component.formsList).to.have.length(0);
+      expect(component.status.uploading).to.equal(false);
+      expect(component.status.error).to.not.exist;
+      expect(component.status.success).to.not.exist;
+    });
+
+    it('should initialise with empty download link and null resourcesDoc', () => {
+      expect(component.download.name).to.equal('');
+      expect(component.download.url).to.equal('');
+      expect(component.resourcesDoc).to.be.null;
+    });
+  });
+
+  // --- ONE ---
+  describe('One', () => {
+    it('should load one form from settings on init', async () => {
+      settingsService.get.resolves(mockSettings({ FORM1: mockForm() }));
+      await stabilize();
+      expect(component.formsList).to.have.length(1);
+      expect(component.formsList[0].meta.code).to.equal('FORM1');
+    });
+
+    it('should load resources document on init', async () => {
+      await stabilize();
+      expect(resourcesService.getResources.callCount).to.equal(1);
+      expect(component.resourcesDoc).to.deep.equal(mockResourcesDoc());
+    });
+
+    it('should generate a download link after loading forms', async () => {
+      settingsService.get.resolves(mockSettings({ FORM1: mockForm() }));
+      await stabilize();
+      expect(component.download.name).to.include('forms_');
+      expect(component.download.name).to.include('.json');
+      expect(component.download.url).to.include('blob:');
+    });
+
+    it('should upload a valid JSON file and save to settings', async () => {
+      await stabilize();
+      const forms = [mockForm({ meta: { code: 'NEW1' } })];
+      triggerFileInput(mockFile(JSON.stringify(forms)));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(settingsService.updateSettings.callCount).to.equal(1);
+    });
+  });
+
+  // --- MANY ---
+  describe('Many', () => {
+    it('should display multiple forms from settings', async () => {
+      settingsService.get.resolves(mockSettings({
+        FORM1: mockForm({ meta: { code: 'FORM1' } }),
+        FORM2: mockForm({ meta: { code: 'FORM2' } }),
+        FORM3: mockForm({ meta: { code: 'FORM3' } }),
+      }));
+      await stabilize();
+      expect(component.formsList).to.have.length(3);
+    });
+
+    it('should uppercase all form codes on upload', async () => {
+      await stabilize();
+      const forms = [
+        { meta: { code: 'form1' } },
+        { meta: { code: 'form2' } },
+      ];
+      triggerFileInput(mockFile(JSON.stringify(forms)));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const savedForms = settingsService.updateSettings.getCall(0).args[0].forms;
+      expect(savedForms).to.have.property('FORM1');
+      expect(savedForms).to.have.property('FORM2');
+    });
+  });
+
+  // --- BOUNDARIES ---
+  describe('Boundaries', () => {
+    it('should handle empty or missing forms from settings', async () => {
+      settingsService.get.resolves(mockSettings({}));
+      await stabilize();
+      expect(component.formsList).to.have.length(0);
+
+      settingsService.get.resolves({});
+      fixture = TestBed.createComponent(SmsFormsComponent);
+      component = fixture.componentInstance;
+      await stabilize();
+      expect(component.formsList).to.have.length(0);
+    });
+
+    it('should skip forms without a meta.code on upload', async () => {
+      await stabilize();
+      const forms = [
+        { meta: { code: 'VALID' } },
+        { meta: {} },
+        {},
+      ];
+      triggerFileInput(mockFile(JSON.stringify(forms)));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const savedForms = settingsService.updateSettings.getCall(0).args[0].forms;
+      expect(Object.keys(savedForms)).to.have.length(1);
+      expect(savedForms).to.have.property('VALID');
+    });
+
+    it('should return empty content from getIconContent when resourcesDoc is null', () => {
+      component.resourcesDoc = null;
+      const result = component.getIconContent('icon-treatment');
+      expect(result.isSvg).to.equal(false);
+      expect(result.content).to.equal('');
+    });
+
+    it('should return empty content from getIconContent when iconName is undefined', async () => {
+      await stabilize();
+      const result = component.getIconContent(undefined);
+      expect(result.isSvg).to.equal(false);
+      expect(result.content).to.equal('');
+    });
+
+    it('should set error status when upload fails', async () => {
+      settingsService.updateSettings.rejects(new Error('Save failed'));
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify([mockForm()])));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(component.status.error).to.equal(true);
+      expect(component.status.uploading).to.equal(false);
+    });
+  });
+
+  // --- INTERFACE ---
+  describe('Interface', () => {
+    it('should call settingsService.get and resourcesService.getResources on init', async () => {
+      await stabilize();
+      expect(settingsService.get.callCount).to.equal(1);
+      expect(resourcesService.getResources.callCount).to.equal(1);
+    });
+
+    it('should call updateSettings with replace true on upload', async () => {
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify([mockForm()])));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(settingsService.updateSettings.calledWith(sinon.match.any, true)).to.equal(true);
+    });
+
+    it('should set success status and update formsList after successful upload', async () => {
+      await stabilize();
+      expect(component.formsList).to.have.length(0);
+      triggerFileInput(mockFile(JSON.stringify([mockForm({ meta: { code: 'UPLOADED' } })])));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(component.status.success).to.equal(true);
+      expect(component.status.uploading).to.equal(false);
+      expect(component.formsList).to.have.length(1);
+      expect(component.formsList[0].meta.code).to.equal('UPLOADED');
+    });
+
+    it('should call resourcesService.getIconContent when resourcesDoc is loaded', async () => {
+      await stabilize();
+      component.getIconContent('icon-treatment');
+      expect(resourcesService.getIconContent.callCount).to.equal(1);
+    });
+
+    it('should wrap SVG content with bypassSecurityTrustHtml', async () => {
+      await stabilize();
+      resourcesService.getIconContent.returns({ isSvg: true, content: '<svg/>' });
+      const result = component.getIconContent('icon-treatment');
+      expect(result.isSvg).to.equal(true);
+      expect(result.content).to.exist;
+    });
+
+    it('should regenerate download link after successful upload', async () => {
+      await stabilize();
+      const oldUrl = component.download.url;
+      triggerFileInput(mockFile(JSON.stringify([mockForm()])));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(component.download.url).to.not.equal(oldUrl);
+    });
+  });
+
+  // --- EXCEPTIONS ---
+  describe('Exceptions', () => {
+    it('should log error and keep empty forms when settings fail to load', async () => {
+      const consoleStub = sinon.stub(console, 'error');
+      settingsService.get.rejects(new Error('Network error'));
+      await stabilize();
+      expect(consoleStub.callCount).to.be.greaterThan(0);
+      expect(component.formsList).to.have.length(0);
+    });
+
+    it('should log error and keep null resourcesDoc when resources fail to load', async () => {
+      const consoleStub = sinon.stub(console, 'error');
+      resourcesService.getResources.rejects(new Error('Network error'));
+      await stabilize();
+      expect(consoleStub.callCount).to.be.greaterThan(0);
+      expect(component.resourcesDoc).to.be.null;
+    });
+
+    it('should set error status when uploaded file is invalid JSON', async () => {
+      await stabilize();
+      triggerFileInput(mockFile('not valid json'));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(component.status.error).to.equal(true);
+    });
+  });
+
+  // --- SCENARIOS ---
+  describe('Scenarios', () => {
+    it('should complete full happy path: load → upload → display new forms', async () => {
+      settingsService.get.resolves(mockSettings({ EXISTING: mockForm({ meta: { code: 'EXISTING' } }) }));
+      await stabilize();
+      expect(component.formsList).to.have.length(1);
+
+      const newForms = [
+        mockForm({ meta: { code: 'NEW1' } }),
+        mockForm({ meta: { code: 'NEW2' } }),
+      ];
+      triggerFileInput(mockFile(JSON.stringify(newForms)));
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(component.formsList).to.have.length(2);
+      expect(component.status.success).to.equal(true);
+      expect(component.status.error).to.equal(false);  // ← was to.not.exist
+    });
+
+    it('should render forms list in the template after load', async () => {
+      settingsService.get.resolves(mockSettings({
+        FORM1: mockForm({ meta: { code: 'FORM1', translation_key: 'form.one' } }),
+      }));
+      await stabilize();
+      fixture.detectChanges();  // ← extra detectChanges to flush template
+      await fixture.whenStable();
+      const rows = fixture.nativeElement.querySelectorAll('ul li');
+      expect(rows.length).to.equal(1);
+    });
+
+    it('should show upload failed message in template on error', async () => {
+      settingsService.updateSettings.rejects(new Error('fail'));
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify([mockForm()])));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      component.status = { uploading: false, error: true };
+      fixture.detectChanges();
+      const error = fixture.nativeElement.querySelector('.error');
+      expect(error).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
# Description

Migrates the SMS Forms tab from the legacy AngularJS admin app to Angular 19 as part of the ongoing admin tool upgrade.

Closes #32

Changes included:
- Added `SmsFormsComponent` with JSON upload, installed forms list and download link
- Form codes are uppercased on upload to match legacy behaviour
- Icon rendering using `ResourcesService` and `DomSanitizer`, supporting both SVG and PNG formats
- Column headers and form rows styled with bold text, larger font and horizontal dividers via `sms-forms.component.less`
- Added `/sms/forms` child route to `sms.routes.ts`
- Added unit tests following ZOMBIES methodology

# Code review checklist
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages.
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
<img width="1476" height="646" alt="Screenshot 2026-05-12 at 2 46 59 PM" src="https://github.com/user-attachments/assets/0777c133-de21-4225-915d-9089a2d13463" />