### PR TITLE
feat(#54): add backup and restore configuration component 

### DIFF
--- a/admin-tool/src/ts/modules/backup/backup.component.html
+++ b/admin-tool/src/ts/modules/backup/backup.component.html
@@ -1,0 +1,44 @@
+<div class="backup-configuration-container">
+
+  <p>{{ 'settings.backuprestore.description' | translate }}</p>
+
+  <div class="tab-content">
+    <legend>{{ 'settings.backup.title' | translate }}</legend>
+    <p>{{ 'settings.backup.description' | translate }}</p>
+    <a
+      class="btn btn-primary"
+      [attr.download]="backup.name"
+      [href]="backup.url"
+    >
+      <i class="fa fa-arrow-down"></i>
+      <span>{{ 'settings.backup.action' | translate }}</span>
+    </a>
+  </div>
+
+  <div class="tab-content">
+    <form>
+      <legend>{{ 'settings.restore.title' | translate }}</legend>
+      <p>{{ 'settings.restore.description' | translate }}</p>
+      <div class="form-actions">
+        <a
+          class="btn btn-primary"
+          [class.disabled]="status.uploading"
+          (click)="onChooseClick($event)"
+        >
+          <i class="fa fa-arrow-up"></i>
+          <span>{{ 'settings.restore.action' | translate }}</span>
+        </a>
+        @if (status.error) {
+          <div class="error">{{ 'Upload failed' | translate }}</div>
+        }
+        @if (status.uploading) {
+          <div class="loader small inline"></div>
+        }
+        <div class="hide">
+          <input #fileInput type="file" accept="application/json" />
+        </div>
+      </div>
+    </form>
+  </div>
+
+</div>

--- a/admin-tool/src/ts/modules/backup/backup.component.ts
+++ b/admin-tool/src/ts/modules/backup/backup.component.ts
@@ -63,7 +63,7 @@ export class BackupComponent implements AfterViewInit, OnDestroy {
   private loadBackup(): void {
     this.settingsService.get()
       .then(settings => {
-        const json = JSON.stringify(settings, null, 4);  // ← add null, 4
+        const json = JSON.stringify(settings, null, 4); 
         const blob = new Blob([json], { type: 'application/json' });
         this.backup = {
           name: 'settings_' + moment().format('YYYY-MM-DD') + '.json',

--- a/admin-tool/src/ts/modules/backup/backup.component.ts
+++ b/admin-tool/src/ts/modules/backup/backup.component.ts
@@ -1,6 +1,130 @@
-import { Component } from '@angular/core';
+import { Component, AfterViewInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { SettingsService } from '@admin-tool-services/settings.service';
+
+const moment = require('moment');
+
+interface BackupStatus {
+  uploading: boolean;
+  error?: boolean;
+  success?: boolean;
+}
+
+interface BackupDownload {
+  name: string;
+  url: string;
+}
 
 @Component({
-  template: `<h2>Backup</h2><p>Backup and restore will be managed here.</p>`,
+  selector: 'app-backup',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  templateUrl: './backup.component.html',
 })
-export class BackupComponent { }
+export class BackupComponent implements AfterViewInit, OnDestroy {
+
+  @ViewChild('fileInput') fileInputRef!: ElementRef<HTMLInputElement>;
+
+  /** Download link data for the settings backup JSON */
+  backup: BackupDownload = { name: '', url: '' };
+
+  /** Tracks the state of the restore upload operation */
+  status: BackupStatus = { uploading: false };
+
+  private changeHandler = (event: Event) => this.upload(event);
+
+  constructor(private readonly settingsService: SettingsService) {}
+
+  ngAfterViewInit(): void {
+    this.fileInputRef.nativeElement.addEventListener('change', this.changeHandler);
+    this.loadBackup();
+  }
+
+  ngOnDestroy(): void {
+    this.fileInputRef?.nativeElement?.removeEventListener('change', this.changeHandler);
+  }
+
+  /**
+   * Triggers the hidden file input click to open the file picker.
+   *
+   * @param {Event} event - the click event from the choose button
+   */
+  onChooseClick(event: Event): void {
+    event.preventDefault();
+    this.fileInputRef.nativeElement.click();
+  }
+
+  /**
+   * Fetches the current settings from the API and generates
+   * a downloadable JSON backup file with a date-stamped filename.
+   */
+  private loadBackup(): void {
+    this.settingsService.get()
+      .then(settings => {
+        const json = JSON.stringify(settings, null, 4);  // ← add null, 4
+        const blob = new Blob([json], { type: 'application/json' });
+        this.backup = {
+          name: 'settings_' + moment().format('YYYY-MM-DD') + '.json',
+          url: URL.createObjectURL(blob),
+        };
+      })
+      .catch(err => console.error('Error fetching settings', err));
+  }
+
+  /**
+   * Handles the file input change event.
+   * Reads the selected JSON file, parses it as settings,
+   * and restores them via updateSettings with replace=true.
+   *
+   * @param {Event} event - the change event from the file input
+   */
+  private upload(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const files = input.files;
+
+    if (!files || files.length === 0) {
+      this.uploadFinished(new Error('File not found'));
+      return;
+    }
+
+    this.status = { uploading: true, error: false, success: false };
+
+    const file = files[0];
+    const reader = new FileReader();
+
+    reader.addEventListener('loadend', () => {
+      try {
+        const settings = JSON.parse(reader.result as string);
+        this.settingsService.updateSettings(settings, true)
+          .then(() => {
+            input.value = '';
+            this.uploadFinished();
+          })
+          .catch(err => this.uploadFinished(err));
+      } catch (err) {
+        this.uploadFinished(err as Error);
+      }
+    });
+
+    reader.addEventListener('error', () => this.uploadFinished(reader.error as Error));
+    reader.readAsText(file);
+  }
+
+  /**
+   * Finalises the upload operation, setting the success or error status.
+   *
+   * @param {Error} err - the error if upload failed, undefined on success
+   */
+  private uploadFinished(err?: Error | null): void {
+    if (err) {
+      console.error('Upload failed', err);
+    }
+    this.status = {
+      uploading: false,
+      error: !!err,
+      success: !err,
+    };
+  }
+}

--- a/admin-tool/tests/karma/ts/modules/backup/backup.component.spec.ts
+++ b/admin-tool/tests/karma/ts/modules/backup/backup.component.spec.ts
@@ -1,36 +1,223 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { expect } from 'chai';
-
+import sinon from 'sinon';
+import { TranslateModule } from '@ngx-translate/core';
 import { BackupComponent } from '@admin-tool-modules/backup/backup.component';
+import { SettingsService } from '@admin-tool-services/settings.service';
+
+const mockSettings = () => ({
+  gateway_number: '+1234567890',
+  default_country_code: '506',
+  locale: 'en',
+});
 
 describe('BackupComponent', () => {
   let component: BackupComponent;
   let fixture: ComponentFixture<BackupComponent>;
+  let settingsService: any;
 
-  beforeEach(waitForAsync(() => {
-    return TestBed
-      .configureTestingModule({
-        imports: [BackupComponent],
-      })
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(BackupComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-      });
-  }));
+  const stabilize = async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await fixture.whenStable();
+  };
 
-  it('should create the backup component', () => {
-    expect(component).to.exist;
+  const mockFile = (content: string, name = 'settings.json'): File => {
+    return new File([content], name, { type: 'application/json' });
+  };
+
+  const triggerFileInput = (file: File) => {
+    const input = fixture.nativeElement.querySelector('input[type="file"]');
+    Object.defineProperty(input, 'files', { value: [file], configurable: true });
+    input.dispatchEvent(new Event('change'));
+  };
+
+  beforeEach(async () => {
+    settingsService = {
+      get: sinon.stub().resolves(mockSettings()),
+      updateSettings: sinon.stub().resolves(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [BackupComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: SettingsService, useValue: settingsService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BackupComponent);
+    component = fixture.componentInstance;
   });
 
-  it('should render the Backup heading', () => {
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h2')!.textContent).to.contain('Backup');
+  afterEach(() => sinon.restore());
+
+  // --- ZERO ---
+  describe('Zero', () => {
+    it('should initialise with empty backup link and clean status', () => {
+      expect(component.backup.name).to.equal('');
+      expect(component.backup.url).to.equal('');
+      expect(component.status.uploading).to.equal(false);
+      expect(component.status.error).to.not.exist;
+      expect(component.status.success).to.not.exist;
+    });
   });
 
-  it('should render a placeholder description paragraph', () => {
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('p')).to.exist;
+  // --- ONE ---
+  describe('One', () => {
+    it('should generate a backup download link on init', async () => {
+      await stabilize();
+      expect(settingsService.get.callCount).to.equal(1);
+      expect(component.backup.name).to.include('settings_');
+      expect(component.backup.name).to.include('.json');
+      expect(component.backup.url).to.include('blob:');
+    });
+
+    it('should restore settings from a valid JSON file', async () => {
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify(mockSettings())));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(settingsService.updateSettings.callCount).to.equal(1);
+    });
+
+    it('should set success status after successful restore', async () => {
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify(mockSettings())));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(component.status.success).to.equal(true);
+      expect(component.status.uploading).to.equal(false);
+      expect(component.status.error).to.equal(false);
+    });
+  });
+
+  // --- BOUNDARIES ---
+  describe('Boundaries', () => {
+    it('should call updateSettings with replace true on restore', async () => {
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify(mockSettings())));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(settingsService.updateSettings.calledWith(sinon.match.any, true)).to.equal(true);
+    });
+
+    it('should set uploading true while restore is in progress', async () => {
+      settingsService.updateSettings.returns(new Promise(() => {}));
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify(mockSettings())));
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(component.status.uploading).to.equal(true);
+    });
+
+    it('should set error status when restore fails', async () => {
+      settingsService.updateSettings.rejects(new Error('Save failed'));
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify(mockSettings())));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(component.status.error).to.equal(true);
+      expect(component.status.uploading).to.equal(false);
+    });
+
+    it('should set error status when uploaded file is invalid JSON', async () => {
+      await stabilize();
+      triggerFileInput(mockFile('not valid json'));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(component.status.error).to.equal(true);
+    });
+  });
+
+  // --- INTERFACE ---
+  describe('Interface', () => {
+    it('should disable the choose button while uploading', async () => {
+      await stabilize();
+      component.status = { uploading: true };
+      fixture.detectChanges();
+      const btn = fixture.nativeElement.querySelector('a.btn.disabled');
+      expect(btn).to.exist;
+    });
+
+    it('should show error message in template on failed restore', async () => {
+      settingsService.updateSettings.rejects(new Error('fail'));
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify(mockSettings())));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      component.status = { uploading: false, error: true };
+      fixture.detectChanges();
+      const error = fixture.nativeElement.querySelector('.error');
+      expect(error).to.exist;
+    });
+
+    it('should show loader while uploading', async () => {
+      await stabilize();
+      component.status = { uploading: true };
+      fixture.detectChanges();
+      const loader = fixture.nativeElement.querySelector('.loader');
+      expect(loader).to.exist;
+    });
+
+    it('should pass the parsed settings object to updateSettings', async () => {
+      await stabilize();
+      const settings = mockSettings();
+      triggerFileInput(mockFile(JSON.stringify(settings)));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const callArg = settingsService.updateSettings.getCall(0).args[0];
+      expect(callArg.locale).to.equal('en');
+      expect(callArg.gateway_number).to.equal('+1234567890');
+    });
+  });
+
+  // --- EXCEPTIONS ---
+  describe('Exceptions', () => {
+    it('should log error and keep empty backup when settings fail to load', async () => {
+      const consoleStub = sinon.stub(console, 'error');
+      settingsService.get.rejects(new Error('Network error'));
+      await stabilize();
+      expect(consoleStub.callCount).to.be.greaterThan(0);
+      expect(component.backup.name).to.equal('');
+    });
+
+    it('should log error and set error status when updateSettings fails', async () => {
+      const consoleStub = sinon.stub(console, 'error');
+      settingsService.updateSettings.rejects(new Error('Save failed'));
+      await stabilize();
+      triggerFileInput(mockFile(JSON.stringify(mockSettings())));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(consoleStub.callCount).to.be.greaterThan(0);
+      expect(component.status.error).to.equal(true);
+    });
+
+    it('should not throw on destroy before ViewChild resolves', () => {
+      expect(() => component.ngOnDestroy()).to.not.throw();
+    });
+  });
+
+  // --- SCENARIOS ---
+  describe('Scenarios', () => {
+    it('should complete full happy path: load → download link generated → restore → success', async () => {
+      await stabilize();
+
+      expect(component.backup.name).to.include('settings_');
+      expect(component.backup.url).to.include('blob:');
+
+      triggerFileInput(mockFile(JSON.stringify(mockSettings())));
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(settingsService.updateSettings.callCount).to.equal(1);
+      expect(component.status.success).to.equal(true);
+      expect(component.status.uploading).to.equal(false);
+    });
+
+    it('should render backup and restore sections in the template', async () => {
+      await stabilize();
+      fixture.detectChanges();
+      const legends = fixture.nativeElement.querySelectorAll('legend');
+      expect(legends.length).to.equal(2);
+    });
+
+    it('should render a download link with correct href after load', async () => {
+      await stabilize();
+      fixture.detectChanges();
+      const link = fixture.nativeElement.querySelector('a[download]');
+      expect(link).to.exist;
+      expect(link.getAttribute('download')).to.include('settings_');
+    });
   });
 });


### PR DESCRIPTION
# Description

Migrates the Backup and Restore Configuration page from the legacy AngularJS admin app to Angular 19 as part of the ongoing admin tool upgrade.

Closes #54

Changes included:
- Added `BackupComponent` with a download button that generates a pretty-printed JSON backup of the current settings
- Added a restore section with a file upload that parses the JSON and replaces the full settings via `updateSettings` with `replace=true`
- Upload button is disabled while restore is in progress
- Error message shown if restore fails
- Added unit tests following ZOMBIES methodology

# Code review checklist
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages.
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
<img width="1489" height="665" alt="Screenshot 2026-05-18 at 9 32 35 AM" src="https://github.com/user-attachments/assets/42964153-0f0f-414e-8f61-687b83d0bc6a" />
